### PR TITLE
Entry now inherits from QObject

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -125,7 +125,7 @@ void MainWindow::on_actionAircraft_triggered()
 
 void MainWindow::on_actionNewFlight_triggered()
 {
-    NewFlightDialog nf = NewFlightDialog(this, Db::createNew);
+    NewFlightDialog nf = NewFlightDialog(Db::createNew, this);
     nf.exec();
 
 }

--- a/src/classes/aircraft.cpp
+++ b/src/classes/aircraft.cpp
@@ -19,13 +19,14 @@
 #include "debug.h"
 
 
-Aircraft::Aircraft()
+Aircraft::Aircraft(QObject *parent)
 {
-
+    this->setParent(parent);
 }
 
-Aircraft::Aircraft(int tail_id)
+Aircraft::Aircraft(int tail_id, QObject *parent)
 {
+    this->setParent(parent);
     //retreive database layout
     const auto dbContent = DbInfo();
     auto table = QLatin1String("tails");
@@ -61,13 +62,14 @@ Aircraft::Aircraft(int tail_id)
     }
 }
 
-Aircraft::Aircraft(QMap<QString, QString> newData)
+Aircraft::Aircraft(QMap<QString, QString> newData, QObject *parent)
 {
+    this->setParent(parent);
     QString table = "tails";
 
     //retreive database layout
     const auto dbContent = DbInfo();
-    columns = dbContent.format.value(table);
+    auto columns = dbContent.format.value(table);
     //Check validity of newData
     QVector<QString> badkeys;
     QMap<QString, QString>::iterator i;

--- a/src/classes/aircraft.h
+++ b/src/classes/aircraft.h
@@ -26,11 +26,11 @@
  */
 class Aircraft : public Entry
 {
-//    using Entry::Entry;
+Q_OBJECT
 public:
-    Aircraft();
-    Aircraft(int tail_id);
-    Aircraft(QMap<QString, QString> newData);
+    Aircraft(QObject* parent = nullptr);
+    Aircraft(int tail_id, QObject* parent = nullptr);
+    Aircraft(QMap<QString, QString> newData, QObject* parent = nullptr);
 };
 
 #endif // AIRCRAFT_H

--- a/src/classes/flight.cpp
+++ b/src/classes/flight.cpp
@@ -18,13 +18,14 @@
 #include "flight.h"
 #include "debug.h"
 
-Flight::Flight()
+Flight::Flight(QObject *parent)
 {
-
+    this->setParent(parent);
 }
 
-Flight::Flight(int flight_id)
+Flight::Flight(int flight_id, QObject *parent)
 {
+    this->setParent(parent);
     //retreive database layout
     const auto dbContent = DbInfo();
 
@@ -62,13 +63,14 @@ Flight::Flight(int flight_id)
     }
 }
 
-Flight::Flight(QMap<QString, QString> newData)
+Flight::Flight(QMap<QString, QString> newData, QObject *parent)
 {
+    this->setParent(parent);
     QString table = "flights";
 
     //retreive database layout
     const auto dbContent = DbInfo();
-    columns = dbContent.format.value(table);
+    auto columns = dbContent.format.value(table);
 
     //Check validity of newData
     QVector<QString> badkeys;

--- a/src/classes/flight.h
+++ b/src/classes/flight.h
@@ -26,11 +26,11 @@
 
 class Flight : public Entry
 {
-//    using Entry::Entry;
+Q_OBJECT
 public:
-    Flight();
-    Flight(int flight_id);
-    Flight(QMap<QString, QString> newData);
+    Flight(QObject* parent = nullptr);
+    Flight(int flight_id, QObject* parent = nullptr);
+    Flight(QMap<QString, QString> newData, QObject* parent = nullptr);
 };
 
 #endif // FLIGHT_H

--- a/src/classes/pilot.cpp
+++ b/src/classes/pilot.cpp
@@ -20,13 +20,14 @@
 
 
 
-Pilot::Pilot()
+Pilot::Pilot(QObject* parent)
 {
-
+    this->setParent(parent);
 }
 
-Pilot::Pilot(int pilot_id)
+Pilot::Pilot(int pilot_id, QObject *parent)
 {
+    this->setParent(parent);
     //retreive database layout
     const auto dbContent = DbInfo();
     auto table = QLatin1String("pilots");
@@ -62,13 +63,14 @@ Pilot::Pilot(int pilot_id)
     }
 }
 
-Pilot::Pilot(QMap<QString, QString> newData)
+Pilot::Pilot(QMap<QString, QString> newData, QObject *parent)
 {
+    this->setParent(parent);
     QString table = "pilots";
 
     //retreive database layout
     const auto dbContent = DbInfo();
-    columns = dbContent.format.value(table);
+    auto columns = dbContent.format.value(table);
 
     //Check validity of newData
     QVector<QString> badkeys;

--- a/src/classes/pilot.h
+++ b/src/classes/pilot.h
@@ -22,11 +22,11 @@
 
 class Pilot : public Entry
 {
-//    using Entry::Entry;
+Q_OBJECT
 public:
-    Pilot();
-    Pilot(int pilot_id);
-    Pilot(QMap<QString, QString> newData);
+    Pilot(QObject* parent = nullptr);
+    Pilot(int pilot_id, QObject* parent = nullptr);
+    Pilot(QMap<QString, QString> newData, QObject* parent = nullptr);
 };
 
 #endif // PILOT_H

--- a/src/database/db.h
+++ b/src/database/db.h
@@ -49,13 +49,17 @@ class Db
          * \brief The editRole enum {createNew, editExisting} is used to differentiate
          * between creating a new entry in the database vs editing an existing one
          */
-        enum editRole {createNew, editExisting};
+        enum editRole { createNew, editExisting };
         /*!
          * \brief The matchType enum {exactMatch, partialMatch} is used to determine the
          * matching when using a WHERE sql statement. exactMatch results in a "=" operator,
          * whereas partiasMatch results in a "LIKE" operator
          */
-        enum matchType {exactMatch, partialMatch};       
+        enum matchType { exactMatch, partialMatch };
+        /*!
+         * \brief The table enum contains the tables accessible in the database
+         */
+        enum table { pilots, tails, flights, aircraft, airports, changelog };
         /*!
          * \brief connect establishes the database connection. Only needs to be called once
          * within the application. Database is available thereafter, objects can be

--- a/src/database/entry.h
+++ b/src/database/entry.h
@@ -26,19 +26,26 @@
  * It can be seen as a row in a table within the database.
  *
  */
-class Entry
+class Entry : public QObject
 {
+    Q_OBJECT
 public:
-    Entry();
-    Entry(QString table, int row);
-    Entry(QString table, QMap<QString, QString> newData);
+    Entry(QObject* parent = nullptr);
+    Entry(QString table, int row, QObject* parent = nullptr); // deprecated
+    Entry(QString table, QMap<QString, QString> newData, QObject* parent = nullptr); // deprecated
+
+    Entry(Db::table table, int row, QObject* parent = nullptr);
+    Entry(Db::table table, QMap<QString, QString> newData, QObject* parent = nullptr);
+
+    QMap<QString, QString> getData() const;
+    void setData(QMap<QString, QString> &value);
+
+    QPair<QString, int> getPosition() const;
+    void setPosition(const QPair<QString, int> &value);
 
     QPair   <QString, int>       position = QPair<QString, int>();    // Position within the database, i.e. <table,row>
-    QVector <QString>            columns  = QVector<QString>();       // The columns within the table
     QMap    <QString, QString>   data     = QMap<QString, QString>(); // Tha data to fill that table, <column,value>
     QString                      error    = QString();                // holds sql errors (if they ocurred)
-
-    void setData(QMap<QString, QString> &value);
 
     bool commit();
     bool remove();
@@ -55,6 +62,11 @@ public:
 private:
     bool insert();
     bool update();
+    QString tableName(Db::table);
+
+signals:
+    void commitSuccessful();
+    void sqlError(QString &errorString);
 };
 
 #endif // ENTRY_H

--- a/src/gui/dialogues/newflightdialog.h
+++ b/src/gui/dialogues/newflightdialog.h
@@ -83,8 +83,8 @@ class NewFlightDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit NewFlightDialog(QWidget *parent, Db::editRole edRole);
-    explicit NewFlightDialog(QWidget *parent, Flight oldFlight, Db::editRole edRole);
+    explicit NewFlightDialog(Db::editRole edRole, QWidget *parent);
+    explicit NewFlightDialog(qint32 rowId, Db::editRole edRole, QWidget *parent);
     ~NewFlightDialog();
 
     //QStringList* getResult();
@@ -95,7 +95,7 @@ private:
 
     void setup();
 
-    void formFiller(Flight oldFlight);
+    void formFiller(qint32 rowId);
 
     void setupLineEdit(QLineEdit* line_edit, LineEditSettings settings);
 
@@ -216,7 +216,8 @@ signals:
 
 private:
     Db::editRole role;
-    Flight entry;
+    //Flight entry;
+    qint32 oldRowId;
     bool doUpdate;
     Ui::NewFlight *ui;
     QMap<QLineEdit*, int> lineEditBitMap;

--- a/src/gui/dialogues/newpilotdialog.cpp
+++ b/src/gui/dialogues/newpilotdialog.cpp
@@ -70,7 +70,7 @@ NewPilotDialog::NewPilotDialog(Pilot existingEntry, Db::editRole edRole, QWidget
     ui(new Ui::NewPilot)
 {
     DEB("New NewPilotDialog\n");
-    oldEntry = existingEntry;
+    oldEntry.position = existingEntry.position;
     role = edRole;
     ui->setupUi(this);
 

--- a/src/gui/dialogues/newtaildialog.h
+++ b/src/gui/dialogues/newtaildialog.h
@@ -48,7 +48,7 @@ public:
     //to create new tail from scratch
     explicit NewTailDialog(QString reg, Db::editRole edRole, QWidget *parent = nullptr);
     //to edit existing tail
-    explicit NewTailDialog(Aircraft dbentry, Db::editRole edRole, QWidget *parent = nullptr);
+    explicit NewTailDialog(int rowId, Db::editRole edRole, QWidget *parent = nullptr);
 
     ~NewTailDialog();
 private slots:
@@ -73,7 +73,7 @@ private:
 
     Db::editRole role;
 
-    Aircraft oldEntry;
+    qint32 rowId;
 
     QStringList aircraftlist;
 
@@ -85,7 +85,7 @@ private:
 
     void setupValidators();
 
-    void formFiller(Entry);
+    void formFiller(Db::table table, int rowId);
 
     bool verify();
 };

--- a/src/gui/widgets/aircraftwidget.cpp
+++ b/src/gui/widgets/aircraftwidget.cpp
@@ -150,7 +150,7 @@ void AircraftWidget::tableView_selectionChanged()
         DEB("Selected Tails(s) with ID: " << selectedTails);
     }
     if(selectedTails.length() == 1) {
-        auto nt = NewTailDialog(Aircraft(selectedTails.first()), Db::editExisting, this);
+        auto nt = NewTailDialog(selectedTails.first(), Db::editExisting, this);
         connect(&nt, SIGNAL(accepted()), this, SLOT(acft_editing_finished()));
         connect(&nt, SIGNAL(rejected()), this, SLOT(acft_editing_finished()));
         ui->stackedWidget->addWidget(&nt);

--- a/src/gui/widgets/homewidget.cpp
+++ b/src/gui/widgets/homewidget.cpp
@@ -38,6 +38,6 @@ HomeWidget::~HomeWidget()
 
 void HomeWidget::on_pushButton_clicked()
 {
-    NewFlightDialog nf(this, Flight(11), Db::editExisting);
+    NewFlightDialog nf(11, Db::editExisting, this);
     nf.exec();
 }

--- a/src/gui/widgets/logbookwidget.cpp
+++ b/src/gui/widgets/logbookwidget.cpp
@@ -149,7 +149,7 @@ void LogbookWidget::tableView_selectionChanged()//
 
 void LogbookWidget::on_newFlightButton_clicked()
 {
-    auto nf = new NewFlightDialog(this, Db::createNew);
+    auto nf = new NewFlightDialog(Db::createNew, this);
     nf->setAttribute(Qt::WA_DeleteOnClose);
     nf->exec();
     refreshView(Settings::read("logbook/view").toInt());
@@ -158,7 +158,7 @@ void LogbookWidget::on_newFlightButton_clicked()
 void LogbookWidget::on_editFlightButton_clicked()
 {
     if(selectedFlights.length() == 1){
-        auto ef = new NewFlightDialog(this,Flight(selectedFlights.first()), Db::editExisting);
+        auto ef = new NewFlightDialog(selectedFlights.first(), Db::editExisting, this);
         ef->setAttribute(Qt::WA_DeleteOnClose);
         ef->exec();
         refreshView(Settings::read("logbook/view").toInt());


### PR DESCRIPTION
The Entry class now inherits from QObject. This has 2 key advantages:
1) Qt can manage our memory if we declare a parent in the constructor of the Entry Object
2) Entry objects can emit signals (e.g. commitSuccessful or sqlError(QString&)

There are also new constructors for an Entry object, which I think will make using the class more user-friendly. Instead of using QString tableName, we can now use an enum Db::table

Example for creating an entry object for a flight at row 34 in the database:

Entry sampleFlight = Entry(Db::flights, 34, this);

I believe with these changes, using subclasses for Pilots, Aircraft and Flights is unneeded bloat and we could remove those classes and use an Entry(Db::flights, int rowID) constructor instead of Flight(rowID). The subclasses as of now don't really do anything else rather than providing a named constructor anyway.