### PR TITLE
Develop cleanup

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -132,11 +132,11 @@ void MainWindow::on_actionDebug_triggered()
 
 void MainWindow::connectWidgets()
 {
-    QObject::connect(experimental::aDB(), &experimental::ADataBase::commitSuccessful,
+    QObject::connect(experimental::aDB(), &experimental::ADataBase::updated,
                      logbookWidget, &LogbookWidget::onDatabaseChanged);
-    QObject::connect(experimental::aDB(), &experimental::ADataBase::commitSuccessful,
+    QObject::connect(experimental::aDB(), &experimental::ADataBase::updated,
                      pilotsWidget, &PilotsWidget::onDatabaseChanged);
-    QObject::connect(experimental::aDB(), &experimental::ADataBase::commitSuccessful,
+    QObject::connect(experimental::aDB(), &experimental::ADataBase::updated,
                      aircraftWidget, &AircraftWidget::onDatabaseChanged);
 }
 

--- a/src/experimental/adatabase.h
+++ b/src/experimental/adatabase.h
@@ -51,6 +51,7 @@ public:
     ADataBase(const ADataBase&) = delete;
     void operator=(const ADataBase&) = delete;
     static ADataBase* getInstance();
+    QString lastError;
 
     /*!
      * \brief The CompleterTarget enum provides the items for which QCompleter
@@ -179,13 +180,15 @@ public:
     const QMap<QString, int> getIdMap(DatabaseTarget);
 
     int getLastEntry(DatabaseTarget);
+
 signals:
-    void commitSuccessful();
-
-    void deleteSuccessful();
-
-    void sqlError(const QSqlError &sqlError, const QString &sqlStatement);
-
+    /*!
+     * \brief updated is emitted whenever the database contents have been updated.
+     * This can be either a commit, update or remove. This signal should be used to
+     * trigger an update to the models of the views displaying database contents in
+     * the user interface so that a user is always presented with up-to-date information.
+     */
+    void updated();
 };
 
 /*!

--- a/src/experimental/aflightentry.cpp
+++ b/src/experimental/aflightentry.cpp
@@ -30,7 +30,7 @@ const QString AFlightEntry::summary()
     return flight_summary;
 }
 
-const QString AFlightEntry::registration()
+const QString AFlightEntry::getRegistration()
 {
     QString tail_id = tableData.value("acft");
     if(tail_id.isEmpty())
@@ -49,7 +49,7 @@ const QString AFlightEntry::registration()
     }
 }
 
-const QString AFlightEntry::pilotName(pilot pilot_)
+const QString AFlightEntry::getPilotName(pilot pilot_)
 {
     QString row_id;
     switch (pilot_) {

--- a/src/experimental/aflightentry.h
+++ b/src/experimental/aflightentry.h
@@ -14,24 +14,24 @@ public:
     AFlightEntry(int row_id);
     AFlightEntry(TableData table_data);
 
-    enum pilot {pic, sic, thirdPilot };
+    enum pilot { pic, sic, thirdPilot };
 
     /*!
-     * \brief Returs a summary of the flight data
+     * \brief Returs a summary of the flight data, if struct holds data
      * \return "doft, dept, tofb, dest, tonb"
      */
     const QString summary();
     /*!
      * \brief Returns the tails' registration from the database.
      */
-    const QString registration();
+    const QString getRegistration();
     /*!
      * \brief Returns the pilots name from the Database
      *
      * \param pilot_number - 1=pic, 2=second Pilot, 3 = third Pilot
      * \return "Lastname, Firstname"
      */
-    const QString pilotName(pilot);
+    const QString getPilotName(pilot);
 };
 
 } // namespace experimental

--- a/src/experimental/atailentry.cpp
+++ b/src/experimental/atailentry.cpp
@@ -31,4 +31,22 @@ ATailEntry::ATailEntry(TableData table_data)
     : AEntry::AEntry(DEFAULT_TAIL_POSITION, table_data)
 {}
 
+const QString ATailEntry::registration()
+{
+    return getData().value("registration");
+}
+
+const QString ATailEntry::type()
+{
+    QString type_string;
+    if (!getData().value("make").isEmpty())
+        type_string.append(getData().value("make") + ' ');
+    if (!getData().value("model").isEmpty())
+        type_string.append(getData().value("model"));
+    if (!getData().value("variant").isEmpty())
+        type_string.append('-' + getData().value("variant") + ' ');
+
+    return type_string;
+}
+
 } // namespace experimental

--- a/src/experimental/atailentry.h
+++ b/src/experimental/atailentry.h
@@ -30,6 +30,10 @@ public:
     ATailEntry& operator=(const ATailEntry& te) = default;
     ATailEntry(int row_id);
     ATailEntry(TableData table_data);
+
+    const QString registration();
+
+    const QString type();
 };
 
 } // namespace experimental

--- a/src/gui/dialogues/newflight.ui
+++ b/src/gui/dialogues/newflight.ui
@@ -17,7 +17,7 @@
    <item row="0" column="0" colspan="2">
     <widget class="QTabWidget" name="flightDataTabWidget">
      <property name="currentIndex">
-      <number>1</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="flightDataTab">
       <attribute name="title">
@@ -826,6 +826,13 @@
          </property>
         </widget>
        </item>
+       <item row="6" column="5">
+        <widget class="QLabel" name="picCompanyLabel">
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
       </layout>
       <zorder>placeLabel2</zorder>
       <zorder>deptLocLineEdit</zorder>
@@ -881,6 +888,7 @@
       <zorder>doftDisplayLabel</zorder>
       <zorder>placeLabel1</zorder>
       <zorder>calendarCheckBox</zorder>
+      <zorder>picCompanyLabel</zorder>
      </widget>
      <widget class="QWidget" name="autoLoggingTab">
       <attribute name="title">

--- a/src/gui/dialogues/newflightdialog.cpp
+++ b/src/gui/dialogues/newflightdialog.cpp
@@ -630,7 +630,7 @@ void NewFlightDialog::formFiller()
         line_edits_names << le->objectName();
     }
 
-    ui->acftLineEdit->setText(flightEntry.registration());
+    ui->acftLineEdit->setText(flightEntry.getRegistration());
     line_edits_names.removeOne("acftLineEdit");
 
     for (const auto& data_key : flightEntry.getData().keys()) {
@@ -1077,7 +1077,7 @@ void NewFlightDialog::on_destLocLineEdit_editingFinished()
 void NewFlightDialog::onLocLineEdit_editingFinished(QLineEdit *line_edit, QLabel *name_label)
 {
     const auto &text = line_edit->text();
-    DEB(line_edit->objectName() << " Editing finished. " << text);
+    //DEB(line_edit->objectName() << " Editing finished. " << text);
     int airport_id = 0;
 
     // try to map iata or icao code to airport id;
@@ -1106,7 +1106,7 @@ void NewFlightDialog::onTimeLineEdit_editingFinished()
 {
     auto sender_object = sender();
     auto line_edit = this->findChild<QLineEdit*>(sender_object->objectName());
-    DEB(line_edit->objectName() << "Editing Finished -" << line_edit->text());
+    //DEB(line_edit->objectName() << "Editing Finished -" << line_edit->text());
 
     line_edit->setText(ACalc::formatTimeInput(line_edit->text()));
     const auto time = QTime::fromString(line_edit->text(),TIME_FORMAT);
@@ -1128,11 +1128,12 @@ void NewFlightDialog::onTimeLineEdit_editingFinished()
 void NewFlightDialog::on_acftLineEdit_editingFinished()
 {
     auto line_edit = ui->acftLineEdit;
-    DEB(line_edit->objectName() << "Editing Finished!" << line_edit->text());
+    //DEB(line_edit->objectName() << "Editing Finished!" << line_edit->text());
 
     if (tailsIdMap.value(line_edit->text()) != 0) {
         DEB("Mapped: " << line_edit->text() << tailsIdMap.value(line_edit->text()));
-        ui->acftTypeLabel->setText(line_edit->text()); // to do: display ac info
+        auto acft = aDB()->getTailEntry(tailsIdMap.value(line_edit->text()));
+        ui->acftTypeLabel->setText(acft.type());
         emit goodInputReceived(line_edit);
         return;
     }
@@ -1159,16 +1160,21 @@ void NewFlightDialog::onPilotNameLineEdit_editingFinished()
 {
     auto sender_object = sender();
     auto line_edit = this->findChild<QLineEdit*>(sender_object->objectName());
-    DEB(line_edit->objectName() << "Editing Finished -" << line_edit->text());
+    //DEB(line_edit->objectName() << "Editing Finished -" << line_edit->text());
 
     if(line_edit->text().contains(SELF_RX)) {
         DEB("self recognized.");
         line_edit->setText(pilotsIdMap.key(1));
+        auto pilot = aDB()->getPilotEntry(1);
+        ui->picCompanyLabel->setText(pilot.getData().value("company"));
         emit goodInputReceived(line_edit);
         return;
     }
+
     if(pilotsIdMap.value(line_edit->text()) != 0) {
         DEB("Mapped: " << line_edit->text() << pilotsIdMap.value(line_edit->text()));
+        auto pilot = aDB()->getPilotEntry(pilotsIdMap.value(line_edit->text()));
+        ui->picCompanyLabel->setText(pilot.getData().value("company"));
         emit goodInputReceived(line_edit);
         return;
     }
@@ -1176,7 +1182,6 @@ void NewFlightDialog::onPilotNameLineEdit_editingFinished()
     if (line_edit->text().isEmpty()) {
         return;
     }
-
 
     if (!line_edit->completer()->currentCompletion().isEmpty()) {
         DEB("Trying to fix input...");
@@ -1272,7 +1277,7 @@ void NewFlightDialog::on_ApproachComboBox_currentTextChanged(const QString &arg1
     }
 }
 
-void NewFlightDialog::on_FunctionComboBox_currentIndexChanged(int index)
+void NewFlightDialog::on_FunctionComboBox_currentIndexChanged(int)
 {
     if (updateEnabled)
         fillDeductibleData();

--- a/src/gui/dialogues/newflightdialog.cpp
+++ b/src/gui/dialogues/newflightdialog.cpp
@@ -866,13 +866,16 @@ void NewFlightDialog::on_submitButton_clicked()
     DEB("Committing...");
     if (!aDB()->commit(flightEntry)) {
         auto message_box = QMessageBox(this);
-        message_box.setText("An error has ocurred. Your entry has not been saved.");
+        message_box.setText("The following error has ocurred:\n\n"
+                            + aDB()->lastError
+                            + "\n\nYour entry has not been saved.");
         message_box.setIcon(QMessageBox::Warning);
         message_box.exec();
         return;
-        /// [F] To do: get error info and display here.
+    } else {
+        QDialog::accept();
     }
-    QDialog::accept();
+
 }
 
 

--- a/src/gui/dialogues/newpilot.ui
+++ b/src/gui/dialogues/newpilot.ui
@@ -128,8 +128,8 @@
   </layout>
  </widget>
  <tabstops>
-  <tabstop>picfirstnameLineEdit</tabstop>
   <tabstop>piclastnameLineEdit</tabstop>
+  <tabstop>picfirstnameLineEdit</tabstop>
   <tabstop>companyLineEdit</tabstop>
   <tabstop>aliasLineEdit</tabstop>
   <tabstop>employeeidLineEdit</tabstop>

--- a/src/gui/dialogues/newpilotdialog.h
+++ b/src/gui/dialogues/newpilotdialog.h
@@ -44,10 +44,6 @@ public:
 
 private slots:
     void on_buttonBox_accepted();
-
-    void onCommitSuccessful();
-
-    void onCommitUnsuccessful(const QSqlError &sqlError, const QString &);
 private:
     Ui::NewPilot *ui;
 

--- a/src/gui/dialogues/newtaildialog.cpp
+++ b/src/gui/dialogues/newtaildialog.cpp
@@ -63,7 +63,7 @@ NewTailDialog::NewTailDialog(int row_id, QWidget *parent) :
     connectSignals();
     setupValidators();
     entry = aDB()->getTailEntry(row_id);
-    fillForm(entry);
+    fillForm(entry, false);
 }
 
 NewTailDialog::~NewTailDialog()
@@ -124,11 +124,15 @@ void NewTailDialog::connectSignals()
  * a tail (ATail, used when editing an existing entry)
  * \param entry
  */
-void NewTailDialog::fillForm(experimental::AEntry entry)
+void NewTailDialog::fillForm(experimental::AEntry entry, bool is_template)
 {
     DEB("Filling Form for (experimental) a/c" << entry.getPosition());
     //fill Line Edits
     auto line_edits = this->findChildren<QLineEdit *>();
+
+    if (is_template)
+        line_edits.removeOne(ui->registrationLineEdit);
+
     for (const auto &le : line_edits) {
         QString name = le->objectName().remove("LineEdit");
         QString value = entry.getData().value(name);
@@ -314,7 +318,7 @@ void NewTailDialog::onSearchCompleterActivated()
             DEB("Template Selected. aircraft_id is: " << idMap.value(text));
             //call autofiller for dialog
             using namespace experimental;
-            fillForm(aDB()->getAircraftEntry(idMap.value(text)));
+            fillForm(aDB()->getAircraftEntry(idMap.value(text)), true);
             ui->searchLineEdit->setStyleSheet("border: 1px solid green");
             ui->searchLabel->setText(text);
         } else {

--- a/src/gui/dialogues/newtaildialog.h
+++ b/src/gui/dialogues/newtaildialog.h
@@ -67,8 +67,6 @@ private:
 
     void setupValidators();
 
-    void connectSignals();
-
     void fillForm(experimental::AEntry entry, bool is_template);
 
     void submitForm();
@@ -91,9 +89,6 @@ private slots:
 
     void onSearchCompleterActivated();
 
-    void onCommitSuccessful();
-
-    void onCommitUnsuccessful(const QSqlError &sqlError, const QString &);
 };
 
 #endif // NEWTAIL_H

--- a/src/gui/dialogues/newtaildialog.h
+++ b/src/gui/dialogues/newtaildialog.h
@@ -69,7 +69,7 @@ private:
 
     void connectSignals();
 
-    void fillForm(experimental::AEntry entry);
+    void fillForm(experimental::AEntry entry, bool is_template);
 
     void submitForm();
 

--- a/src/gui/widgets/debugwidget.cpp
+++ b/src/gui/widgets/debugwidget.cpp
@@ -166,11 +166,9 @@ void DebugWidget::on_debugPushButton_clicked()
 {
     using namespace experimental;
 
-    auto pilotsIdMap  = aDB()->getIdMap(ADataBase::pilots);
-    auto pilotList    = aDB()->getCompletionList(ADataBase::pilots);
-
-    DEB(pilotsIdMap.key(aDB()->getLastEntry(ADataBase::pilots)));
-    DEB(pilotList);
+    auto acft = aDB()->getTailEntry(5);
+    DEB(acft.getData().key("make"));
+    DEB(acft.type());
 
 
 }

--- a/src/gui/widgets/logbookwidget.h
+++ b/src/gui/widgets/logbookwidget.h
@@ -60,9 +60,6 @@ private slots:
 
     void on_actionDelete_Flight_triggered();
 
-    void onDeletedSuccessfully();
-    void onDeleteUnsuccessful(const QSqlError);
-
     void on_actionEdit_Flight_triggered();
 
     void on_tableView_doubleClicked();


### PR DESCRIPTION

- Added database member variable lastError which replaces sqlError signal and holds error information.

- Logbookwidget, for (un)successful deletion now uses if statements

- NewTailDialog and NewPilotDialog now use if statements and boolean returns for accepting the dialog

- Edited Tab order in NewTailDialog

- Fixed a bug in NewTailDialog where loading a template would overwrite the registration

- Added some information to pilot and acft display in NewFlightDialog