### PR TITLE
Develop debugwidget refactor

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -51,7 +51,6 @@ int main(int argc, char *argv[])
     ASettings::setup();
 
     AStyle::setup();
-
     aDB()->connect();
     if (!ASettings::read(ASettings::Setup::SetupComplete).toBool()) {
         if(FirstRunDialog().exec() == QDialog::Rejected){

--- a/src/database/adatabase.h
+++ b/src/database/adatabase.h
@@ -77,8 +77,6 @@ public:
 class ADatabase : public QObject {
     Q_OBJECT
 private:
-    TableNames tableNames;
-    TableColumns tableColumns;
     static ADatabase* instance;
     ADatabase();
 public:
@@ -87,7 +85,7 @@ public:
     void operator=(const ADatabase&) = delete;
     static ADatabase* getInstance();
     TableNames getTableNames() const;
-    TableColumns getTableColumns() const;
+    TableColumns getTableColumns(TableName table_name) const;
     const QString sqliteVersion();
 
     ADatabaseError lastError;

--- a/src/database/adatabase.h
+++ b/src/database/adatabase.h
@@ -79,13 +79,16 @@ class ADatabase : public QObject {
 private:
     static ADatabase* instance;
     ADatabase();
+    TableNames tableNames;
+    TableColumns tableColumns;
 public:
     // Ensure DB is not copiable or assignable
     ADatabase(const ADatabase&) = delete;
     void operator=(const ADatabase&) = delete;
     static ADatabase* getInstance();
     TableNames getTableNames() const;
-    TableColumns getTableColumns(TableName table_name) const;
+    ColumnNames getTableColumns(TableName table_name) const;
+    void updateLayout();
     const QString sqliteVersion();
 
     ADatabaseError lastError;
@@ -232,6 +235,8 @@ public:
      * \return The Tail Entry referencted by the foreign key.
      */
     ATailEntry resolveForeignTail(int foreign_key);
+
+
 
 
 

--- a/src/database/adatabasesetup.cpp
+++ b/src/database/adatabasesetup.cpp
@@ -266,6 +266,8 @@ bool ADataBaseSetup::createDatabase()
         return false;
     }
 
+    aDB()->updateLayout();
+
     DEB << "Populating tables...";
     if (!importDefaultData()) {
         DEB << "Populating tables failed.";

--- a/src/database/adatabasesetup.cpp
+++ b/src/database/adatabasesetup.cpp
@@ -266,9 +266,6 @@ bool ADataBaseSetup::createDatabase()
         return false;
     }
 
-    // call connect again to (re-)populate tableNames and columnNames
-    aDB()->connect();
-
     DEB << "Populating tables...";
     if (!importDefaultData()) {
         DEB << "Populating tables failed.";
@@ -415,25 +412,25 @@ bool ADataBaseSetup::createSchemata(const QStringList &statements)
  * \param tableName as in the database
  * \return
  */
-bool ADataBaseSetup::commitData(QVector<QStringList> fromCSV, const QString &tableName)
+bool ADataBaseSetup::commitData(QVector<QStringList> from_csv, const QString &table_name)
 {
     DEB << "Table names: " << aDB()->getTableNames();
-    DEB << "Importing Data to" << tableName;
-    if (!aDB()->getTableNames().contains(tableName)){
-        DEB << tableName << "is not a table in the database. Aborting.";
+    DEB << "Importing Data to" << table_name;
+    if (!aDB()->getTableNames().contains(table_name)){
+        DEB << table_name << "is not a table in the database. Aborting.";
         DEB << "Please check input data.";
         return false;
     }
     // create insert statement
-    QString statement = "INSERT INTO " + tableName + " (";
+    QString statement = "INSERT INTO " + table_name + " (";
     QString placeholder = ") VALUES (";
-    for (auto& csvColumn : fromCSV) {
-        if(aDB()->getTableColumns().value(tableName).contains(csvColumn.first())) {
+    for (auto& csvColumn : from_csv) {
+        if(aDB()->getTableColumns(table_name).contains(csvColumn.first())) {
             statement += csvColumn.first() + ',';
             csvColumn.removeFirst();
             placeholder.append("?,");
         } else {
-            DEB << csvColumn.first() << "is not a column of " << tableName << "Aborting.";
+            DEB << csvColumn.first() << "is not a column of " << table_name << "Aborting.";
             DEB << "Please check input data.";
             return false;
         }
@@ -449,12 +446,12 @@ bool ADataBaseSetup::commitData(QVector<QStringList> fromCSV, const QString &tab
      */
     QSqlQuery query;
     query.exec("BEGIN EXCLUSIVE TRANSACTION;");
-    for (int i = 0; i < fromCSV.first().length(); i++){
+    for (int i = 0; i < from_csv.first().length(); i++){
         query.prepare(statement);
-        for(int j = 0; j < fromCSV.length(); j++) {
-             fromCSV[j][i] == QString("") ? // make sure NULL is committed for empty values
+        for(int j = 0; j < from_csv.length(); j++) {
+             from_csv[j][i] == QString("") ? // make sure NULL is committed for empty values
                          query.addBindValue(QVariant(QVariant::String))
-                       : query.addBindValue(fromCSV[j][i]);
+                       : query.addBindValue(from_csv[j][i]);
              //query.addBindValue(fromCSV[j][i]);
          }
         query.exec();
@@ -465,7 +462,7 @@ bool ADataBaseSetup::commitData(QVector<QStringList> fromCSV, const QString &tab
         DEB << "Error:" << query.lastError().text();
         return false;
     } else {
-        qDebug() << tableName << "Database successfully updated!";
+        qDebug() << table_name << "Database successfully updated!";
         return true;
     }
 }

--- a/src/database/adatabasesetup.h
+++ b/src/database/adatabasesetup.h
@@ -47,7 +47,7 @@ public:
 
     static bool resetToDefault();
 
-    static bool commitData(QVector<QStringList> fromCSV, const QString &tableName);
+    static bool commitData(QVector<QStringList> from_csv, const QString &table_name);
 
 private:
 

--- a/src/database/declarations.h
+++ b/src/database/declarations.h
@@ -17,35 +17,11 @@ using TableName = QString;
 using RowId = int;
 
 using TableNames = QStringList;
-// [G]: May lead to some confusion. TableData suggest data for the entire table.
-// but in reallity it is data per column *of single row* (unless i misunderstand)
-// [F]: That's correct. We could maybe call it EntryData or RowData?
 using RowData = QMap<ColName, ColData>;
 using ColumnData = QPair<ColName, ColData>;
 using ColumnNames = QStringList;
-using TableColumns = QStringList;
+using TableColumns = QMap<TableName, ColumnNames>;
 
-// [G]: Needs some work. Inheriting from QPair may be helpful but
-// may also be overkill. Lets determine the specific uses of DataPosition
-// and provide our own interface i would say.
-// [F]: Good idea! Implementing something similar to first and second methods
-// of QPair would be useful to carry over, or some other way of quickly and
-// unambiguously accessing the elements.
-/*struct DataPosition : QPair<TableName, RowId> {
-    TableName tableName;
-    RowId rowId;
-    DataPosition()
-        : tableName(first), rowId(second)
-    {}
-    DataPosition(TableName table_name, RowId row_id)
-        : QPair<TableName, RowId>::QPair(table_name, row_id),
-          tableName(first), rowId(second)
-    {}
-    DataPosition(const DataPosition& other) = default;
-    DataPosition& operator=(const DataPosition& other) = default;
-};*/
-
-//[F]: How about something like this?
 struct DataPosition {
     TableName tableName;
     RowId rowId;

--- a/src/database/declarations.h
+++ b/src/database/declarations.h
@@ -23,7 +23,7 @@ using TableNames = QStringList;
 using RowData = QMap<ColName, ColData>;
 using ColumnData = QPair<ColName, ColData>;
 using ColumnNames = QStringList;
-using TableColumns = QMap<TableName, ColumnNames>;
+using TableColumns = QStringList;
 
 // [G]: Needs some work. Inheriting from QPair may be helpful but
 // may also be overkill. Lets determine the specific uses of DataPosition

--- a/src/gui/dialogues/firstrundialog.cpp
+++ b/src/gui/dialogues/firstrundialog.cpp
@@ -120,8 +120,6 @@ bool FirstRunDialog::finish()
         db_fail_msg_box.exec();
         return false;
     }
-    aDB()->disconnect(); // reset db connection to refresh layout after initial setup.
-    aDB()->connect();
 
     auto pilot = APilotEntry(1);
     pilot.setData(data);

--- a/src/gui/dialogues/firstrundialog.cpp
+++ b/src/gui/dialogues/firstrundialog.cpp
@@ -114,12 +114,12 @@ bool FirstRunDialog::finish()
     auto db_fail_msg_box = QMessageBox(QMessageBox::Critical, QStringLiteral("Database setup failed"),
                                        QStringLiteral("Errors have ocurred creating the database."
                                                       "Without a working database The application will not be usable."));
-    // [G]: Im abit confused on the logic here
-    // why do you write setup complete twice?
     if (!setupDatabase()) {
         db_fail_msg_box.exec();
         return false;
     }
+
+    aDB()->updateLayout();
 
     auto pilot = APilotEntry(1);
     pilot.setData(data);
@@ -147,10 +147,11 @@ bool FirstRunDialog::setupDatabase()
     aDB()->connect();
 
     // [F]: todo: handle unsuccessful steps
-    // [G]: only two / for comments
-    // three are shorthand for documentation
     if(!ADataBaseSetup::createDatabase())
         return false;
+
+    aDB()->updateLayout();
+
     if(!ADataBaseSetup::importDefaultData())
         return false;
     return true;

--- a/src/gui/dialogues/firstrundialog.ui
+++ b/src/gui/dialogues/firstrundialog.ui
@@ -30,6 +30,9 @@
    </item>
    <item row="0" column="0" colspan="2">
     <widget class="QStackedWidget" name="stackedWidget">
+     <property name="currentIndex">
+      <number>2</number>
+     </property>
      <widget class="QWidget" name="stackedWidgetPage1">
       <layout class="QGridLayout" name="gridLayout_2">
        <item row="0" column="1">
@@ -397,7 +400,7 @@
        <item row="0" column="0" colspan="2">
         <widget class="QLabel" name="label_4">
          <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:16pt;&quot;&gt;Finish&lt;/span&gt;&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;&lt;br/&gt;Almost done! Here you can select the theme to be used for the application.&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;This change will take effect the next time the application is launched.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:16pt;&quot;&gt;Finish&lt;/span&gt;&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;&lt;br/&gt;Almost done! We are now going to create the database for the application.&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;If you want to use the most up-to-date version of the database, an internet connection is required, otherwise you can use the version included in the download.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="textFormat">
           <enum>Qt::RichText</enum>

--- a/src/gui/widgets/debugwidget.cpp
+++ b/src/gui/widgets/debugwidget.cpp
@@ -1,6 +1,9 @@
 #include "debugwidget.h"
 #include "ui_debugwidget.h"
 #include "src/classes/astandardpaths.h"
+#include "src/gui/widgets/logbookwidget.h"
+#include "src/gui/widgets/pilotswidget.h"
+#include "src/gui/widgets/aircraftwidget.h"
 
 DebugWidget::DebugWidget(QWidget *parent) :
     QWidget(parent),
@@ -24,10 +27,9 @@ void DebugWidget::on_resetUserTablesPushButton_clicked()
     ATimer timer(this);
     QMessageBox result;
     if (ADataBaseSetup::resetToDefault()){
-        result.setText("Database successfully reset.\n\nRestarting app.");
+        result.setText("Database successfully reset");
         result.exec();
-        qApp->quit();
-        QProcess::startDetached(qApp->arguments()[0], qApp->arguments());
+        touchDatabase();
     } else {
         result.setText("Errors have occurred. Check console for Debug output. ");
         result.exec();
@@ -37,52 +39,47 @@ void DebugWidget::on_resetUserTablesPushButton_clicked()
 void DebugWidget::on_resetDatabasePushButton_clicked()
 {
     ATimer timer(this);
-    QMessageBox mb(this);
-    //check if template dir exists and create if needed.
-    QDir dir("data/templates");
-    DEB << dir.path();
-    if (!dir.exists())
-        dir.mkpath(".");
+    QMessageBox message_box(this);
+
     // download latest csv
-    QStringList templateTables = {"aircraft", "airports", "changelog"};
-    QString linkStub = "https://raw.githubusercontent.com/fiffty-50/openpilotlog/";
-    linkStub.append(ui->branchLineEdit->text());
-    linkStub.append("/assets/database/templates/");
-    for (const auto& table : templateTables) {
+    QString link_stub = "https://raw.githubusercontent.com/fiffty-50/openpilotlog/";
+    link_stub.append(ui->branchLineEdit->text()); // optionally select branch for development
+    link_stub.append("/assets/database/templates/");
+
+    QStringList template_tables = {"aircraft", "airports", "changelog"};
+    QDir template_dir(AStandardPaths::absPathOf(AStandardPaths::Templates));
+    for (const auto& table : template_tables) {
         QEventLoop loop;
         ADownload* dl = new ADownload;
-        connect(dl, &ADownload::done, &loop, &QEventLoop::quit );
-        dl->setTarget(QUrl(linkStub + table + ".csv"));
-        dl->setFileName("data/templates/" + table + ".csv");
+        QObject::connect(dl, &ADownload::done, &loop, &QEventLoop::quit );
+        dl->setTarget(QUrl(link_stub % table % QStringLiteral(".csv")));
+        dl->setFileName(template_dir.filePath(table % QStringLiteral(".csv")));
         dl->download();
         loop.exec(); // event loop waits for download done signal before allowing loop to continue
         dl->deleteLater();
     }
 
-    //close database connection
+    // back up old db
     aDB()->disconnect();
+    ADataBaseSetup::backupOldData();
 
-    // back up and remove old database
-    auto oldDatabase = QFile("data/logbook.db");
-    if (oldDatabase.exists()) {
-        auto dateString = QDateTime::currentDateTime().toString(Qt::ISODate);
-        DEB << "Backing up old database as: " << "logbook-backup-" + dateString + ".db";
-        if (oldDatabase.copy("data/logbook-backup-" + dateString + ".db")) {
-            oldDatabase.remove();
-            DEB << "Old Database removed.";
-        }
-
-    }
     // re-connct and create new database
     aDB()->connect();
-
     if (ADataBaseSetup::createDatabase()) {
-        mb.setText("Database has been successfully reset.\n\nRestarting application.");
-        mb.exec();
-        qApp->quit();
-        QProcess::startDetached(qApp->arguments()[0], qApp->arguments());
+        DEB << "Database has been successfully created.";
     } else {
-        mb.setText("Errors have ocurred. Check console for details.");
+        message_box.setText("Errors have ocurred creating the database.<br>"
+                            "Check console for details.");
+        message_box.exec();
+    }
+    if (ADataBaseSetup::importDefaultData()) {
+        message_box.setText("Database has been successfully reset.");
+        touchDatabase();
+        message_box.exec();
+    } else {
+        message_box.setText("Errors have ocurred while importing templates.<br>"
+                            "Check console for details.");
+        message_box.exec();
     }
 }
 
@@ -94,24 +91,21 @@ void DebugWidget::downloadFinished()
 void DebugWidget::on_fillUserDataPushButton_clicked()
 {
     ATimer timer(this);
-    QMessageBox mb(this);
-    //check if template dir exists and create if needed.
-    QDir dir("data/templates");
-    DEB << dir.path();
-    if (!dir.exists())
-        dir.mkpath(".");
+    QMessageBox message_box(this);
     // download latest csv
     QStringList userTables = {"pilots", "tails", "flights"};
     QString linkStub = "https://raw.githubusercontent.com/fiffty-50/openpilotlog/";
     linkStub.append(ui->branchLineEdit->text());
     linkStub.append("/assets/database/templates/sample_");
+    QDir template_dir(AStandardPaths::absPathOf(AStandardPaths::Templates));
 
     for (const auto& table : userTables) {
         QEventLoop loop;
         ADownload* dl = new ADownload;
         connect(dl, &ADownload::done, &loop, &QEventLoop::quit );
         dl->setTarget(QUrl(linkStub + table + ".csv"));
-        dl->setFileName("data/templates/sample_" + table + ".csv");
+        dl->setFileName(template_dir.filePath("sample_" + table % QStringLiteral(".csv")));
+        //dl->setFileName("data/templates/sample_" + table + ".csv");
         dl->download();
         loop.exec(); // event loop waits for download done signal before allowing loop to continue
         dl->deleteLater();
@@ -120,26 +114,28 @@ void DebugWidget::on_fillUserDataPushButton_clicked()
     allGood.resize(userTables.size());
 
     for (const auto& table : userTables) {
-        auto data = aReadCsv("data/templates/sample_" + table + ".csv");
+        auto data = aReadCsv(AStandardPaths::absPathOf(AStandardPaths::Templates)
+                             + "/sample_" + table + ".csv");
         allGood.setBit(userTables.indexOf(table), ADataBaseSetup::commitData(data, table));
     }
 
     if (allGood.count(true) != userTables.size()) {
-        mb.setText("Errors have ocurred. Check console for details.");
-        mb.exec();
+        message_box.setText("Errors have ocurred. Check console for details.");
+        message_box.exec();
         return;
     }
 
-    mb.setText("User tables successfully populated.\n\nRestarting app.");
-    mb.exec();
-    qApp->quit();
-    QProcess::startDetached(qApp->arguments()[0], qApp->arguments());
+    message_box.setText("User tables successfully populated.");
+    message_box.exec();
+    touchDatabase();
 }
 
 void DebugWidget::on_selectCsvPushButton_clicked()
 {
     auto fileName = QFileDialog::getOpenFileName(this,
-                                                 tr("Open CSV File for import"), QDir::homePath(), tr("CSV files (*.csv)"));
+                                                 tr("Open CSV File for import"),
+                                                 AStandardPaths::absPathOf(AStandardPaths::Templates),
+                                                 tr("CSV files (*.csv)"));
     ui->importCsvLineEdit->setText(fileName);
 }
 
@@ -169,7 +165,20 @@ void DebugWidget::on_importCsvPushButton_clicked()
 
 void DebugWidget::on_debugPushButton_clicked()
 {
-    DEB << AStandardPaths::allPaths()[AStandardPaths::Database	];
+    touchDatabase();
+}
+
+/*!
+ * \brief Acess the database to trigger aDB()::databaseUpdated
+ */
+void DebugWidget::touchDatabase()
+{
+    QMap<QString, QVariant> debugData;
+    debugData.insert("lastname","debugLastName");
+    debugData.insert("firstname","debugFirstName");
+    auto pilot = APilotEntry(1);
+    pilot.setData(debugData);
+    aDB()->commit(pilot);
 }
 
 /* //Comparing two functions template

--- a/src/gui/widgets/debugwidget.cpp
+++ b/src/gui/widgets/debugwidget.cpp
@@ -29,7 +29,7 @@ void DebugWidget::on_resetUserTablesPushButton_clicked()
     if (ADataBaseSetup::resetToDefault()){
         result.setText("Database successfully reset");
         result.exec();
-        touchDatabase();
+        emit aDB()->dataBaseUpdated();
     } else {
         result.setText("Errors have occurred. Check console for Debug output. ");
         result.exec();
@@ -74,7 +74,7 @@ void DebugWidget::on_resetDatabasePushButton_clicked()
     }
     if (ADataBaseSetup::importDefaultData()) {
         message_box.setText("Database has been successfully reset.");
-        touchDatabase();
+        emit aDB()->dataBaseUpdated();
         message_box.exec();
     } else {
         message_box.setText("Errors have ocurred while importing templates.<br>"
@@ -127,7 +127,7 @@ void DebugWidget::on_fillUserDataPushButton_clicked()
 
     message_box.setText("User tables successfully populated.");
     message_box.exec();
-    touchDatabase();
+    emit aDB()->dataBaseUpdated();
 }
 
 void DebugWidget::on_selectCsvPushButton_clicked()
@@ -165,20 +165,7 @@ void DebugWidget::on_importCsvPushButton_clicked()
 
 void DebugWidget::on_debugPushButton_clicked()
 {
-    touchDatabase();
-}
 
-/*!
- * \brief Acess the database to trigger aDB()::databaseUpdated
- */
-void DebugWidget::touchDatabase()
-{
-    QMap<QString, QVariant> debugData;
-    debugData.insert("lastname","debugLastName");
-    debugData.insert("firstname","debugFirstName");
-    auto pilot = APilotEntry(1);
-    pilot.setData(debugData);
-    aDB()->commit(pilot);
 }
 
 /* //Comparing two functions template

--- a/src/gui/widgets/debugwidget.h
+++ b/src/gui/widgets/debugwidget.h
@@ -51,8 +51,6 @@ private:
     Ui::DebugWidget *ui;
 
     bool downloadComplete = false;
-
-    void touchDatabase();
 };
 
 #endif // DEBUGWIDGET_H

--- a/src/gui/widgets/debugwidget.h
+++ b/src/gui/widgets/debugwidget.h
@@ -51,6 +51,8 @@ private:
     Ui::DebugWidget *ui;
 
     bool downloadComplete = false;
+
+    void touchDatabase();
 };
 
 #endif // DEBUGWIDGET_H


### PR DESCRIPTION
DebugWidget now makes use of standardpaths, no more need to restart application after database changes.

Update of ADatabase to address an issue that ocurred when the database was modified, but the tableNames and columnNames member variables had outdated information since they were only once written when connect() was called. See commit [159c391](https://github.com/fiffty-50/openpilotlog/commit/159c391d9b75dd58608efe7a7f2514d546ce2c14) for a detailed description of the issue.