### PR TITLE
Develop qt 5 9 5 refactor

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -98,9 +98,9 @@ MainWindow::~MainWindow()
 
 void MainWindow::nope()
 {
-    QMessageBox nope(this); //error box
-    nope.setText("This feature is not yet available!");
-    nope.exec();
+    QMessageBox message_box(this); //error box
+    message_box.setText("This feature is not yet available!");
+    message_box.exec();
 }
 
 
@@ -158,19 +158,19 @@ void MainWindow::on_actionAircraft_triggered()
 
 void MainWindow::on_actionNewFlight_triggered()
 {
-    NewFlightDialog nf = NewFlightDialog(this);
+    NewFlightDialog nf(this);
     nf.exec();
 
 }
 
 void MainWindow::on_actionNewAircraft_triggered()
 {
-    NewTailDialog nt = NewTailDialog(QString(), this);
+    NewTailDialog nt(QString(), this);
     nt.exec();
 }
 
 void MainWindow::on_actionNewPilot_triggered()
 {
-    NewPilotDialog np = NewPilotDialog(this);
+    NewPilotDialog np(this);
     np.exec();
 }

--- a/openPilotLog.pro
+++ b/openPilotLog.pro
@@ -14,6 +14,7 @@ DEFINES += QT_DEPRECATED_WARNINGS
 # In order to do so, uncomment the following line.
 # You can also select to disable deprecated APIs only up to a certain version of Qt.
 DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0
+QMAKE_CXXFLAGS += -Wno-deprecated-copy # see https://bugreports.qt.io/browse/QTBUG-75210
 
 # [G]: need to fix this. There must be a src/* command or smth
 SOURCES += \

--- a/openPilotLog.pro
+++ b/openPilotLog.pro
@@ -2,7 +2,7 @@ QT       += core gui sql network
 
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 
-CONFIG += c++17
+CONFIG += c++1z
 
 # The following define makes your compiler emit warnings if you use
 # any Qt feature that has been marked deprecated (the exact warnings
@@ -13,7 +13,7 @@ DEFINES += QT_DEPRECATED_WARNINGS
 # You can also make your code fail to compile if it uses deprecated APIs.
 # In order to do so, uncomment the following line.
 # You can also select to disable deprecated APIs only up to a certain version of Qt.
-#DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0
+DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0
 
 # [G]: need to fix this. There must be a src/* command or smth
 SOURCES += \

--- a/src/classes/asettings.cpp
+++ b/src/classes/asettings.cpp
@@ -147,7 +147,5 @@ QString ASettings::stringOfKey (const ASettings::Setup key)
 QString ASettings::stringOfKey (const ASettings::UserData key)
 { return  userDataMap[key]; }
 
-
-
-QSettings ASettings::settings()
-{ return QSettings(); }
+// [F]: removed because the function was unused and wouldn't compile with qt 5.9.5. Not sure why it did in the first place.
+// see https://doc.qt.io/archives/qt-5.9/qobject.html#no-copy-constructor-or-assignment-operator for info

--- a/src/classes/astyle.cpp
+++ b/src/classes/astyle.cpp
@@ -5,11 +5,10 @@
 #include "src/testing/adebug.h"
 #include "src/classes/asettings.h"
 
-#ifdef __linux__
-const QString AStyle::defaultStyle = QStringLiteral("fusion");
-#elif defined(_WIN32) || defined(_WIN64)
-const QString AStyle::defaultStyle = QStringLiteral("Windows");
-#endif
+// this was throwing hundreds of warnings on 5.9.5, fusion is a good default for all platforms, let's
+// stick with that for now.
+const QString AStyle::defaultStyle = QStringLiteral("Fusion");
+
 const QString AStyle::defaultStyleSheet = QStringLiteral("");
 
 const QStringList AStyle::styles = QStyleFactory::keys();
@@ -73,7 +72,8 @@ void AStyle::setStyle(const QString style)
 
 void AStyle::setStyleSheet(const StyleSheet stylesheet)
 {
-    DEB << "Setting stylesheet to:" << defaultStyleSheets[stylesheet];
+    // [F]: qt 5.9.5 compatibility
+    DEB << "Setting stylesheet to:" << defaultStyleSheets[stylesheet].baseName();
     qApp->setStyleSheet(read_stylesheet(stylesheet));
     ASettings::write(ASettings::Main::StyleSheet, stylesheet);
     currentStyleSheet = defaultStyleSheets[stylesheet].fileName();

--- a/src/database/adatabase.cpp
+++ b/src/database/adatabase.cpp
@@ -282,8 +282,8 @@ bool ADatabase::update(AEntry updated_entry)
     QSqlQuery query;
     query.prepare(statement);
     for (auto i = data.constBegin(); i != data.constEnd(); ++i) {
-        if (i.value() == QVariant(QVariant::String)) {
-            query.addBindValue(QVariant(QVariant::String));
+        if (i.value() == QVariant(QString())) {
+            query.addBindValue(QVariant(QString()));
         } else {
             query.addBindValue(i.value());
         }
@@ -327,8 +327,8 @@ bool ADatabase::insert(AEntry new_entry)
     query.prepare(statement);
 
     for (i = data.begin(); i != data.end(); ++i) {
-        if (i.value() == "") {
-            query.addBindValue(QVariant(QVariant::String));
+        if (i.value() == QVariant(QString())) {
+            query.addBindValue(QVariant(QString()));
         } else {
             query.addBindValue(i.value());
         }

--- a/src/database/adatabase.cpp
+++ b/src/database/adatabase.cpp
@@ -68,7 +68,6 @@ void ADatabase::updateLayout()
     emit dataBaseUpdated();
 }
 
-inline
 ADatabase* ADatabase::instance()
 {
 #ifdef __GNUC__

--- a/src/database/adatabasesetup.cpp
+++ b/src/database/adatabasesetup.cpp
@@ -416,8 +416,7 @@ bool ADataBaseSetup::createSchemata(const QStringList &statements)
  */
 bool ADataBaseSetup::commitData(QVector<QStringList> from_csv, const QString &table_name)
 {
-    DEB << "Table names: " << aDB->getTableNames();
-    DEB << "Importing Data to" << table_name;
+    aDB->updateLayout();
     if (!aDB->getTableNames().contains(table_name)){
         DEB << table_name << "is not a table in the database. Aborting.";
         DEB << "Please check input data.";
@@ -452,7 +451,7 @@ bool ADataBaseSetup::commitData(QVector<QStringList> from_csv, const QString &ta
         query.prepare(statement);
         for(int j = 0; j < from_csv.length(); j++) {
              from_csv[j][i] == QString("") ? // make sure NULL is committed for empty values
-                         query.addBindValue(QVariant(QVariant::String))
+                         query.addBindValue(QVariant(QString()))
                        : query.addBindValue(from_csv[j][i]);
              //query.addBindValue(fromCSV[j][i]);
          }

--- a/src/functions/astat.cpp
+++ b/src/functions/astat.cpp
@@ -123,9 +123,9 @@ QVector<QPair<QString, QString>> AStat::totals()
     for (const auto &column : columns) {
         value = query.value(columns.indexOf(column)).toString();
         if (!value.isEmpty()) {
-            output << QPair{column, value};
+            output.append(QPair<QString, QString>{column, value});
         } else {
-            output << QPair{column, QString("00:00")};
+            output.append(QPair<QString, QString>{column, QString("00:00")});
         }
     }
     return output;

--- a/src/gui/dialogues/newflightdialog.cpp
+++ b/src/gui/dialogues/newflightdialog.cpp
@@ -26,15 +26,6 @@
 
 #include "src/testing/adebug.h"
 
-/////////////////////////////////////// DEBUG /////////////////////////////////////////////////////
-void NewFlightDialog::onInputRejected()
-{
-    auto sender_object = sender();
-    auto line_edit = this->findChild<QLineEdit*>(sender_object->objectName());
-    DEB << line_edit->objectName() << "Input Rejected - " << line_edit->text();
-}
-/////////////////////////////////////// DEBUG /////////////////////////////////////////////////////
-
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 ///                                         constants                                           ///
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -282,10 +273,6 @@ void NewFlightDialog::setupSignalsAndSlots()
     auto line_edits = this->findChildren<QLineEdit*>();
 
     for (const auto &line_edit : line_edits){
-        /////////////////////////////////////// DEBUG /////////////////////////////////////////////////////
-        QObject::connect(line_edit, &QLineEdit::inputRejected,
-                         this, &NewFlightDialog::onInputRejected);
-        /////////////////////////////////////// DEBUG /////////////////////////////////////////////////////
         line_edit->installEventFilter(this);
         if(line_edit->objectName().contains("Loc")){
             QObject::connect(line_edit, &QLineEdit::textChanged,

--- a/src/gui/dialogues/newflightdialog.h
+++ b/src/gui/dialogues/newflightdialog.h
@@ -56,10 +56,6 @@ public:
 
 private slots:
 
-    /////// DEBUG
-        void onInputRejected();
-    /////// DEBUG
-
     void onToUpperTriggered_textChanged(const QString&);
     void onPilotNameLineEdit_editingFinished();
     void onLocationEditingFinished(QLineEdit*, QLabel*);

--- a/src/gui/dialogues/newpilotdialog.cpp
+++ b/src/gui/dialogues/newpilotdialog.cpp
@@ -53,7 +53,7 @@ static const auto COMPANY_VALID = QPair<QString, QRegularExpression> {
 static const auto EMPLOYEENR_VALID = QPair<QString, QRegularExpression> {
      "employeeidLineEdit", QRegularExpression("\\w+")};
 
-static const auto LINE_EDIT_VALIDATORS = QVector{
+static const auto LINE_EDIT_VALIDATORS = QVector<QPair<QString, QRegularExpression>> {
         FIRSTNAME_VALID,
         LASTNAME_VALID,
         PHONE_VALID,

--- a/src/gui/dialogues/newpilotdialog.cpp
+++ b/src/gui/dialogues/newpilotdialog.cpp
@@ -118,9 +118,9 @@ void NewPilotDialog::setup()
 void NewPilotDialog::on_buttonBox_accepted()
 {
     if (ui->lastnameLineEdit->text().isEmpty() || ui->firstnameLineEdit->text().isEmpty()) {
-        auto mb = QMessageBox(this);
-        mb.setText("Last Name and First Name are required.");
-        mb.show();
+        QMessageBox message_box(this);
+        message_box.setText("Last Name and First Name are required.");
+        message_box.show();
     } else {
         submitForm();
     }

--- a/src/gui/dialogues/newtaildialog.cpp
+++ b/src/gui/dialogues/newtaildialog.cpp
@@ -27,7 +27,7 @@ static const auto MODEL_VALID = QPair<QString, QRegularExpression> {
     "modelLineEdit", QRegularExpression("[\\s\\w-]+")};
 static const auto VARIANT_VALID = QPair<QString, QRegularExpression> {
     "variantLineEdit", QRegularExpression("[\\s\\w-]+")};
-static const auto LINE_EDIT_VALIDATORS = QVector({REG_VALID, MAKE_VALID, MODEL_VALID, VARIANT_VALID});
+static const auto LINE_EDIT_VALIDATORS = QVector<QPair<QString, QRegularExpression>>({REG_VALID, MAKE_VALID, MODEL_VALID, VARIANT_VALID});
 
 
 NewTailDialog::NewTailDialog(QString new_registration, QWidget *parent) :

--- a/src/gui/dialogues/newtaildialog.cpp
+++ b/src/gui/dialogues/newtaildialog.cpp
@@ -264,11 +264,11 @@ void NewTailDialog::on_buttonBox_accepted()
 
     if (!verify()) {
         if (!ASettings::read(ASettings::UserData::AcAllowIncomplete).toInt()) {
-            auto nope = QMessageBox(this);
-            nope.setIcon(QMessageBox::Warning);
-            nope.setText("Some or all recommended fields are empty.\nPlease go back and "
+            QMessageBox message_box(this);
+            message_box.setIcon(QMessageBox::Warning);
+            message_box.setText("Some or all recommended fields are empty.\nPlease go back and "
                          "complete the form.\n\nYou can allow logging incomplete tail entries on the settings page.");
-            nope.exec();
+            message_box.exec();
             return;
         } else {
             QMessageBox::StandardButton reply;

--- a/src/gui/widgets/aircraftwidget.cpp
+++ b/src/gui/widgets/aircraftwidget.cpp
@@ -84,14 +84,14 @@ void AircraftWidget::setupModelAndView()
 void AircraftWidget::on_deleteButton_clicked()
 {
     if (selectedTails.length() == 0) {
-        auto mb = QMessageBox(this);
-        mb.setText(QStringLiteral("No Aircraft selected."));
-        mb.exec();
+        QMessageBox message_box(this);
+        message_box.setText(QStringLiteral("No Aircraft selected."));
+        message_box.exec();
 
     } else if (selectedTails.length() > 1) {
-        auto mb = QMessageBox(this);
-        mb.setText(QStringLiteral("Deleting multiple entries is currently not supported"));
-        mb.exec();
+        QMessageBox message_box(this);
+        message_box.setText(QStringLiteral("Deleting multiple entries is currently not supported"));
+        message_box.exec();
         /// [F] to do: for (const auto& row_id : selectedPilots) { do batchDelete }
         /// I am not sure if enabling this functionality for this widget is a good idea.
         /// On the one hand, deleting many entries could be useful in a scenario where
@@ -103,7 +103,7 @@ void AircraftWidget::on_deleteButton_clicked()
 
     } else if (selectedTails.length() == 1) {
         auto entry = aDB->getTailEntry(selectedTails.first());
-        auto message_box = QMessageBox(this);
+        QMessageBox message_box(this);
         QString message = "You are deleting the following aircraft:<br><br><b><tt>";
         message.append(entry.registration() + QStringLiteral(" - (") + entry.type() + ')');
         message.append(QStringLiteral("</b></tt><br><br>Are you sure?"));

--- a/src/gui/widgets/debugwidget.cpp
+++ b/src/gui/widgets/debugwidget.cpp
@@ -4,6 +4,7 @@
 #include "src/gui/widgets/logbookwidget.h"
 #include "src/gui/widgets/pilotswidget.h"
 #include "src/gui/widgets/aircraftwidget.h"
+#include <QtGlobal>
 
 DebugWidget::DebugWidget(QWidget *parent) :
     QWidget(parent),
@@ -165,7 +166,15 @@ void DebugWidget::on_importCsvPushButton_clicked()
 
 void DebugWidget::on_debugPushButton_clicked()
 {
-
+#if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
+    DEB << "SSL version use for build: " << QSslSocket::sslLibraryBuildVersionString();
+    DEB << "SSL version use for run-time: " << QSslSocket::sslLibraryVersionNumber();
+    DEB << QT_VERSION_MAJOR << QT_VERSION_MINOR << "At least 5.12";
+#else
+    DEB << "SSL version use for build: " << QSslSocket::sslLibraryBuildVersionString();
+    DEB << "SSL version use for run-time: " << QSslSocket::sslLibraryVersionNumber();
+    DEB << QT_VERSION_MAJOR << QT_VERSION_MINOR << "Less than 5.12";
+#endif
 }
 
 /* //Comparing two functions template

--- a/src/gui/widgets/debugwidget.cpp
+++ b/src/gui/widgets/debugwidget.cpp
@@ -105,8 +105,7 @@ void DebugWidget::on_fillUserDataPushButton_clicked()
         ADownload* dl = new ADownload;
         connect(dl, &ADownload::done, &loop, &QEventLoop::quit );
         dl->setTarget(QUrl(linkStub + table + ".csv"));
-        dl->setFileName(template_dir.filePath("sample_" + table % QStringLiteral(".csv")));
-        //dl->setFileName("data/templates/sample_" + table + ".csv");
+        dl->setFileName(template_dir.filePath("sample_" % table % QStringLiteral(".csv")));
         dl->download();
         loop.exec(); // event loop waits for download done signal before allowing loop to continue
         dl->deleteLater();
@@ -166,15 +165,7 @@ void DebugWidget::on_importCsvPushButton_clicked()
 
 void DebugWidget::on_debugPushButton_clicked()
 {
-#if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
-    DEB << "SSL version use for build: " << QSslSocket::sslLibraryBuildVersionString();
-    DEB << "SSL version use for run-time: " << QSslSocket::sslLibraryVersionNumber();
-    DEB << QT_VERSION_MAJOR << QT_VERSION_MINOR << "At least 5.12";
-#else
-    DEB << "SSL version use for build: " << QSslSocket::sslLibraryBuildVersionString();
-    DEB << "SSL version use for run-time: " << QSslSocket::sslLibraryVersionNumber();
-    DEB << QT_VERSION_MAJOR << QT_VERSION_MINOR << "Less than 5.12";
-#endif
+    // space for debugging
 }
 
 /* //Comparing two functions template
@@ -202,31 +193,11 @@ void DebugWidget::on_debugPushButton_clicked()
     DEB << "Second block executed " << number_of_runs << " times for a total of " << time2 << " milliseconds.");
 */
 
+/*
+ *#if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
+ *   DEB << QT_VERSION_MAJOR << QT_VERSION_MINOR << "At least 5.12";
+ *#else
+ *   DEB << QT_VERSION_MAJOR << QT_VERSION_MINOR << "Less than 5.12";
+ * #endif
+ */
 
-
-
-/*qlonglong number_of_runs = 500;
-        long time1 = 0;
-        {
-
-            ATimer timer;
-            for (int i = 0; i < number_of_runs; i++) {
-                // first block, do stuff here...
-                auto acft = aDB->getTailEntry(5);
-                auto pilot = aDB->getPilotEntry(7);
-                auto flight = aDB->getFlightEntry(15);
-                QList<AEntry> list = {acft, pilot, flight};
-                for (auto entry : list) {
-                    for (auto column : entry.getData()) {
-                        QString value = column.toString();
-                    }
-                }
-            }
-
-            time1 = timer.timeNow();
-        }
-
-        DEB << "First block executed " << number_of_runs << " times for a total of " << time1 << " milliseconds.");
-        // 108 - 134 milliseconds with legacy exp db api
-        // 108 - 110 milliseconds with improved exp api
-        // to do: with string literals*/

--- a/src/gui/widgets/debugwidget.cpp
+++ b/src/gui/widgets/debugwidget.cpp
@@ -25,14 +25,14 @@ DebugWidget::~DebugWidget()
 void DebugWidget::on_resetUserTablesPushButton_clicked()
 {
     ATimer timer(this);
-    QMessageBox result;
+    QMessageBox message_box(this);
     if (ADataBaseSetup::resetToDefault()){
-        result.setText("Database successfully reset");
-        result.exec();
+        message_box.setText("Database successfully reset");
+        message_box.exec();
         emit aDB->dataBaseUpdated();
     } else {
-        result.setText("Errors have occurred. Check console for Debug output. ");
-        result.exec();
+        message_box.setText("Errors have occurred. Check console for Debug output. ");
+        message_box.exec();
     }
 }
 
@@ -148,18 +148,18 @@ void DebugWidget::on_importCsvPushButton_clicked()
     if (file.exists() && file.isFile()) {
 
         if (ADataBaseSetup::commitData(aReadCsv(file.absoluteFilePath()), ui->tableComboBox->currentText())) {
-            auto mb = QMessageBox(this);
-            mb.setText("Data inserted successfully.");
-            mb.exec();
+            QMessageBox message_box(this);
+            message_box.setText("Data inserted successfully.");
+            message_box.exec();
         } else {
-            auto mb = QMessageBox(this);
-            mb.setText("Errors have ocurred. Check console for details.");
-            mb.exec();
+            QMessageBox message_box(this);
+            message_box.setText("Errors have ocurred. Check console for details.");
+            message_box.exec();
         }
     } else {
-        auto mb = QMessageBox(this);
-        mb.setText("Please select a valid file.");
-        mb.exec();
+        QMessageBox message_box(this);
+        message_box.setText("Please select a valid file.");
+        message_box.exec();
     }
 }
 

--- a/src/gui/widgets/pilotswidget.cpp
+++ b/src/gui/widgets/pilotswidget.cpp
@@ -132,14 +132,14 @@ void PilotsWidget::on_newPilotButton_clicked()
 void PilotsWidget::on_deletePilotButton_clicked()
 {
     if (selectedPilots.length() == 0) {
-        auto mb = QMessageBox(this);
-        mb.setText("No Pilot selected.");
-        mb.exec();
+        QMessageBox message_box(this);
+        message_box.setText("No Pilot selected.");
+        message_box.exec();
 
     } else if (selectedPilots.length() > 1) {
-        auto mb = QMessageBox(this);
-        mb.setText("Deleting multiple entries is currently not supported");
-        mb.exec();
+        QMessageBox message_box(this);
+        message_box.setText("Deleting multiple entries is currently not supported");
+        message_box.exec();
         /// [F] to do: for (const auto& row_id : selectedPilots) { do batchDelete }
         /// I am not sure if enabling this functionality for this widget is a good idea.
         /// On the one hand, deleting many entries could be useful in a scenario where

--- a/src/gui/widgets/settingswidget.cpp
+++ b/src/gui/widgets/settingswidget.cpp
@@ -42,7 +42,7 @@ static const auto EMPLOYEENR_VALID = QPair<QString, QRegularExpression> {
 static const auto PREFIX_VALID = QPair<QString, QRegularExpression> {
     "prefixLineEdit", QRegularExpression("[a-zA-Z0-9]?[a-zA-Z0-9]?[a-zA-Z0-9]")};
 
-static const auto LINE_EDIT_VALIDATORS = QVector({FIRSTNAME_VALID, LASTNAME_VALID,
+static const auto LINE_EDIT_VALIDATORS = QVector<QPair<QString, QRegularExpression>>({FIRSTNAME_VALID, LASTNAME_VALID,
                                            PHONE_VALID,     EMAIL_VALID,
                                            COMPANY_VALID,     EMPLOYEENR_VALID,
                                            PREFIX_VALID});


### PR DESCRIPTION
Some minor adjustments to ensure compatibility with earlier qt versions, specifically Qt 5.9.5, which is included in Ubuntu 18.04 LTS and would be a sensible target for creating an appimage with broad compatibility (with 16.04 ending support in April 2021). 

The changes are minor and mostly related to syntax. As a general observation, I noticed that older versions of Qt seem to be less forgiving when creating QVectors, QPairs and the like when the template arguments are not explicitly specified, so we should keep the following in mind for further development:

```cpp
auto var = QPair{value, value} // not good
auto var = QPair<T,T>{value, value} // better
```

Apart from that, nothing really noteworthy, I encountered a problem with ADownload but upon investigation that was a problem in my configuration.

Misc:

- Inline removed from definition of ADatabase::instance() since it gave linker errors.
- Adjusted the .pro file to account for older nomenclature (c++1z vs c++17), and surpress unwanted warnings related to [QTBUG-68156](https://bugreports.qt.io/browse/QTBUG-68156)
- Fusion style default for all platforms

Users and developers who compile with never versions of qt should be unaffected by these changes.