### PR TITLE
Fix for bug #51

### DIFF
--- a/src/classes/astyle.h
+++ b/src/classes/astyle.h
@@ -13,9 +13,9 @@ class AStyle
 {
 public:
     enum StyleSheet{
-        Dark = 0,
+        Default = 0,  // Nothing read from config file produces .UInt() == 0
+        Dark,
         Light,
-        Default,
     };
 private:
     static QString currentStyle;

--- a/src/database/adatabasesetup.cpp
+++ b/src/database/adatabasesetup.cpp
@@ -302,7 +302,11 @@ bool ADataBaseSetup::backupOldData()
         return true;
     }
 
-    auto date_string = QDateTime::currentDateTime().toString("yyyy_MM_dd_T_hh_mm");
+    auto date_string = QDateTime::currentDateTime().toString(Qt::ISODate);
+#if defined(_WIN32) || defined(_WIN64)
+    date_string.replace(':', '-');
+#endif
+    DEB << date_string;
     auto backup_dir = QDir(AStandardPaths::absPathOf(AStandardPaths::DatabaseBackup));
     auto backup_name = database_file.baseName() % "_bak_" % date_string + ".db";
     auto file = QFile(aDB->databaseFile.absoluteFilePath());

--- a/src/database/adatabasesetup.cpp
+++ b/src/database/adatabasesetup.cpp
@@ -302,12 +302,12 @@ bool ADataBaseSetup::backupOldData()
         return true;
     }
 
-    auto date_string = QDateTime::currentDateTime().toString(Qt::ISODate);
+    auto date_string = QDateTime::currentDateTime().toString("yyyy_MM_dd_T_hh_mm");
     auto backup_dir = QDir(AStandardPaths::absPathOf(AStandardPaths::DatabaseBackup));
-    auto backup_name = database_file.baseName() + "_bak_" + date_string + ".db";
+    auto backup_name = database_file.baseName() % "_bak_" % date_string + ".db";
     auto file = QFile(aDB->databaseFile.absoluteFilePath());
 
-    if (!file.rename(backup_dir.absolutePath() + '/' + backup_name)) {
+    if (!file.rename(backup_dir.absolutePath() % '/' % backup_name)) {
         DEB << "Unable to backup old database.";
         return false;
     }
@@ -398,7 +398,7 @@ bool ADataBaseSetup::createSchemata(const QStringList &statements)
 
     if (!errors.isEmpty()) {
         DEB_SRC << "The following errors have ocurred: ";
-        for (const auto& error : errors) {
+        for (const auto& error : qAsConst(errors)) { //[F]: To prevent container from detaching https://doc.qt.io/qt-5/qtglobal.html#qAsConst
             DEB_RAW << error;
         }
         return false;

--- a/src/database/adatabasesetup.h
+++ b/src/database/adatabasesetup.h
@@ -29,6 +29,7 @@ const auto TEMPLATE_URL = QStringLiteral("https://raw.githubusercontent.com/fiff
  * the application is first launched. It creates the database in the specified default
  * location and creates all required tables and views. It can also be used to reset the
  * database currently used
+ * \todo Convert to namespace (no data encapsulated so reason to bloat memory.
  */
 class ADataBaseSetup
 {

--- a/src/functions/acalc.h
+++ b/src/functions/acalc.h
@@ -2,6 +2,7 @@
 #define ACALC_H
 
 #include <QDateTime>
+#define _USE_MATH_DEFINES // needed for MSVC
 #include <cmath>
 #include <QDebug>
 /*!


### PR DESCRIPTION
Fixed a bug that was putting a not cross-platform safe character into a filename.

Added a cast to avoid container detachment ref https://doc.qt.io/qt-5/qtglobal.html#qAsConst

closes #51 