### PR TITLE
Guards against unsuccessful Downloads in FirstRunDialog

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,7 @@ set(PROJECT_SOURCES
     src/gui/widgets/totalswidget.ui
     assets/icons.qrc
     assets/themes/breeze.qrc
+    assets/templates.qrc
 )
 
 if(${QT_VERSION_MAJOR} GREATER_EQUAL 6)

--- a/assets/templates.qrc
+++ b/assets/templates.qrc
@@ -1,0 +1,7 @@
+<RCC>
+    <qresource prefix="/templates">
+        <file>database/templates/aircraft.csv</file>
+        <file>database/templates/airports.csv</file>
+        <file>database/templates/changelog.csv</file>
+    </qresource>
+</RCC>

--- a/main.cpp
+++ b/main.cpp
@@ -42,8 +42,7 @@ int main(int argc, char *argv[])
     QCoreApplication::setApplicationName(APPNAME);
 
     AStandardPaths::setup();
-    AStandardPaths::scan_dirs();
-    if(!AStandardPaths::validate_dirs()){
+    if(!AStandardPaths::scan_dirs()){
         DEB << "Standard paths not valid.";
         return 1;
     }

--- a/main.cpp
+++ b/main.cpp
@@ -49,21 +49,25 @@ int main(int argc, char *argv[])
     ASettings::setup();
 
     AStyle::setup();
-    aDB->connect();
+
+    if (!aDB->connect()) {
+        DEB << "Error establishing database connection";
+        return 2;
+    }
+
     if (!ASettings::read(ASettings::Setup::SetupComplete).toBool()) {
         if(FirstRunDialog().exec() == QDialog::Rejected){
-            DEB "First run not accepted. Exiting.";
-            return 1;
+            DEB << "First run not accepted. Exiting.";
+            return 3;
         }
         ASettings::write(ASettings::Setup::SetupComplete, true);
         DEB << "Wrote setup_commplete?";
     }
 
-    //sqlite does not deal well with multiple connections, ensure only one instance is running
     ARunGuard guard(QStringLiteral("opl_single_key"));
     if ( !guard.tryToRun() ){
-        DEB << "Another Instance is already running. Exiting.";
-        return 2;
+        DEB << "Another Instance of openPilotLog is already running. Exiting.";
+        return 0;
     }
 
 

--- a/main.cpp
+++ b/main.cpp
@@ -41,8 +41,7 @@ int main(int argc, char *argv[])
     QCoreApplication::setOrganizationDomain(ORGDOMAIN);
     QCoreApplication::setApplicationName(APPNAME);
 
-    AStandardPaths::setup();
-    if(!AStandardPaths::scan_dirs()){
+    if(!AStandardPaths::setup()){
         DEB << "Standard paths not valid.";
         return 1;
     }

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -24,7 +24,6 @@ MainWindow::MainWindow(QWidget *parent)
     : QMainWindow(parent)
     , ui(new Ui::MainWindow)
 {
-    ATimer timer(this);
     ui->setupUi(this);
 
     // Set up Toolbar

--- a/openPilotLog.pro
+++ b/openPilotLog.pro
@@ -108,6 +108,7 @@ else: unix:!android: target.path = /opt/$${TARGET}/bin
 
 RESOURCES += \
     assets/icons.qrc \
+    assets/templates.qrc \
     assets/themes/breeze.qrc
 
 DISTFILES += \

--- a/src/classes/aaircraftentry.h
+++ b/src/classes/aaircraftentry.h
@@ -1,3 +1,20 @@
+/*
+ *openPilot Log - A FOSS Pilot Logbook Application
+ *Copyright (C) 2020  Felix Turowsky
+ *
+ *This program is free software: you can redistribute it and/or modify
+ *it under the terms of the GNU General Public License as published by
+ *the Free Software Foundation, either version 3 of the License, or
+ *(at your option) any later version.
+ *
+ *This program is distributed in the hope that it will be useful,
+ *but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *GNU General Public License for more details.
+ *
+ *You should have received a copy of the GNU General Public License
+ *along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 #ifndef AAIRCRAFTENTRY_H
 #define AAIRCRAFTENTRY_H
 

--- a/src/classes/adownload.cpp
+++ b/src/classes/adownload.cpp
@@ -28,7 +28,7 @@ ADownload::ADownload() : QObject(nullptr)
 
 ADownload::~ADownload()
 {
-
+    DEB << "Deleting ADownload Object";
 }
 
 void ADownload::setTarget(const QUrl &value)

--- a/src/classes/adownload.cpp
+++ b/src/classes/adownload.cpp
@@ -28,7 +28,7 @@ ADownload::ADownload() : QObject(nullptr)
 
 ADownload::~ADownload()
 {
-    DEB << "Deleting Download object" ;
+
 }
 
 void ADownload::setTarget(const QUrl &value)
@@ -65,7 +65,7 @@ void ADownload::downloadFinished(QNetworkReply *data)
     const QByteArray sdata = data->readAll();
     localFile.write(sdata);
     localFile.close();
-    DEB << "Download finished. Output file: " << fileName;
+    DEB << "Download finished. Output file: " << fileName << "size: " << localFile.size();
 
     emit done();
 }

--- a/src/classes/asettings.cpp
+++ b/src/classes/asettings.cpp
@@ -16,7 +16,6 @@
  *along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include "asettings.h"
-#include "astandardpaths.h"
 #include <QSettings>
 
 
@@ -147,6 +146,3 @@ QString ASettings::stringOfKey (const ASettings::Setup key)
 
 QString ASettings::stringOfKey (const ASettings::UserData key)
 { return  userDataMap[key]; }
-
-// [F]: removed because the function was unused and wouldn't compile with qt 5.9.5. Not sure why it did in the first place.
-// see https://doc.qt.io/archives/qt-5.9/qobject.html#no-copy-constructor-or-assignment-operator for info

--- a/src/classes/astandardpaths.cpp
+++ b/src/classes/astandardpaths.cpp
@@ -1,30 +1,33 @@
 #include "src/classes/astandardpaths.h"
 
-QMap<AStandardPaths::Dirs, QString> AStandardPaths::dirs;
+QMap<AStandardPaths::Directories, QString> AStandardPaths::directories;
 
 void AStandardPaths::setup()
 {
     auto data_location = QStandardPaths::AppDataLocation;
-    dirs = {  // [G]: potential rename to `dirs`
-        {Database, QStandardPaths::writableLocation(data_location)},
-        {Templates, QDir(QStandardPaths::writableLocation(data_location)).filePath("templates")},
-        {DatabaseBackup, QDir(QStandardPaths::writableLocation(data_location)).filePath("backup")}
+    directories = { // [F]: Dir could be ambiguous since it is very similar to QDir
+        {Database, QDir::toNativeSeparators(
+         QStandardPaths::writableLocation(data_location) + '/')},
+        {Templates, QDir::toNativeSeparators(
+         QDir(QStandardPaths::writableLocation(data_location)).filePath(QStringLiteral("templates/")))},
+        {DatabaseBackup, QDir::toNativeSeparators(
+         QDir(QStandardPaths::writableLocation(data_location)).filePath(QStringLiteral("backup/")))}
     };
 }
 
-const QString& AStandardPaths::absPathOf(Dirs loc)
+const QString& AStandardPaths::absPathOf(Directories loc)
 {
-    return dirs[loc];
+    return directories[loc];
 }
 
-const QMap<AStandardPaths::Dirs, QString>& AStandardPaths::allPaths()
+const QMap<AStandardPaths::Directories, QString>& AStandardPaths::allPaths()
 {
-    return dirs;
+    return directories;
 }
 
 void AStandardPaths::scan_dirs()
 {
-    for(auto& dir : dirs){
+    for(auto& dir : directories){
         auto d = QDir(dir);
         if(!d.exists()) {
             d.mkpath(dir);
@@ -32,9 +35,14 @@ void AStandardPaths::scan_dirs()
     }
 }
 
+// [F]: We could make scan_dirs return bool and return false if !exists && !mkpath
+// This function seems like it would do the same as scan_dirs
+// Validating the contents would be rather complex to accomplish and difficult to
+// maintain I believe, since the contents of these directories might change and it
+// seems out of the scope of this class to verify the directories' contents.
 bool AStandardPaths::validate_dirs()
 {
-    for(auto& dir : dirs){
+    for(auto& dir : directories){
         //DEB << "Validating " << dir;
         if(false)  // determine path as valid (scan contents and parse for correctness)
             return false;

--- a/src/classes/astandardpaths.cpp
+++ b/src/classes/astandardpaths.cpp
@@ -1,51 +1,37 @@
 #include "src/classes/astandardpaths.h"
 
-QMap<AStandardPaths::Directories, QString> AStandardPaths::directories;
+QMap<AStandardPaths::Directories, QDir> AStandardPaths::directories;
 
 void AStandardPaths::setup()
 {
     auto data_location = QStandardPaths::AppDataLocation;
     directories = { // [F]: Dir could be ambiguous since it is very similar to QDir
-        {Database, QDir::toNativeSeparators(
-         QStandardPaths::writableLocation(data_location) + '/')},
-        {Templates, QDir::toNativeSeparators(
-         QDir(QStandardPaths::writableLocation(data_location)).filePath(QStringLiteral("templates/")))},
-        {DatabaseBackup, QDir::toNativeSeparators(
-         QDir(QStandardPaths::writableLocation(data_location)).filePath(QStringLiteral("backup/")))}
+        {Database, QDir(QStandardPaths::writableLocation(data_location) + '/')},
+        {Templates, QDir(QStandardPaths::writableLocation(data_location)).filePath(
+         QStringLiteral("templates/"))},
+        {Backup, QDir(QStandardPaths::writableLocation(data_location)).filePath(
+         QStringLiteral("backup/"))}
     };
 }
 
-const QString& AStandardPaths::absPathOf(Directories loc)
+const QDir& AStandardPaths::directory(Directories loc)
 {
     return directories[loc];
 }
 
-const QMap<AStandardPaths::Directories, QString>& AStandardPaths::allPaths()
+const QMap<AStandardPaths::Directories, QDir>& AStandardPaths::allDirectories()
 {
     return directories;
 }
 
-void AStandardPaths::scan_dirs()
+bool AStandardPaths::scan_dirs()
 {
-    for(auto& dir : directories){
-        auto d = QDir(dir);
-        if(!d.exists()) {
-            d.mkpath(dir);
+    for(const auto& dir : directories){
+        if(!dir.exists()) {
+            DEB << dir << "Does not exist. Creating: " << dir.absolutePath();
+            if (!dir.mkpath(dir.absolutePath()))
+                return false;
         }
-    }
-}
-
-// [F]: We could make scan_dirs return bool and return false if !exists && !mkpath
-// This function seems like it would do the same as scan_dirs
-// Validating the contents would be rather complex to accomplish and difficult to
-// maintain I believe, since the contents of these directories might change and it
-// seems out of the scope of this class to verify the directories' contents.
-bool AStandardPaths::validate_dirs()
-{
-    for(auto& dir : directories){
-        //DEB << "Validating " << dir;
-        if(false)  // determine path as valid (scan contents and parse for correctness)
-            return false;
     }
     return true;
 }

--- a/src/classes/astandardpaths.cpp
+++ b/src/classes/astandardpaths.cpp
@@ -1,22 +1,43 @@
+/*
+ *openPilot Log - A FOSS Pilot Logbook Application
+ *Copyright (C) 2020  Felix Turowsky
+ *
+ *This program is free software: you can redistribute it and/or modify
+ *it under the terms of the GNU General Public License as published by
+ *the Free Software Foundation, either version 3 of the License, or
+ *(at your option) any later version.
+ *
+ *This program is distributed in the hope that it will be useful,
+ *but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *GNU General Public License for more details.
+ *
+ *You should have received a copy of the GNU General Public License
+ *along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 #include "src/classes/astandardpaths.h"
 
 QMap<AStandardPaths::Directories, QDir> AStandardPaths::directories;
 
-void AStandardPaths::setup()
+bool AStandardPaths::setup()
 {
     auto data_location = QStandardPaths::AppDataLocation;
-    directories = { // [F]: Dir could be ambiguous since it is very similar to QDir
-        {Database, QDir(QStandardPaths::writableLocation(data_location) + '/')},
-        {Templates, QDir(QStandardPaths::writableLocation(data_location)).filePath(
-         QStringLiteral("templates/"))},
-        {Backup, QDir(QStandardPaths::writableLocation(data_location)).filePath(
-         QStringLiteral("backup/"))}
+    directories = {
+        {Database, QDir(QStandardPaths::writableLocation(data_location))},
+        {Templates, QDir(QStandardPaths::writableLocation(data_location)
+         + QStringLiteral("/templates"))},
+        {Backup, QDir(QStandardPaths::writableLocation(data_location)
+         + QStringLiteral("/backup"))}
     };
+    if (scan_directories())
+        return true;
+
+    return false;
 }
 
-const QDir& AStandardPaths::directory(Directories loc)
+const QDir& AStandardPaths::directory(Directories location)
 {
-    return directories[loc];
+    return directories[location];
 }
 
 const QMap<AStandardPaths::Directories, QDir>& AStandardPaths::allDirectories()
@@ -24,11 +45,11 @@ const QMap<AStandardPaths::Directories, QDir>& AStandardPaths::allDirectories()
     return directories;
 }
 
-bool AStandardPaths::scan_dirs()
+bool AStandardPaths::scan_directories()
 {
     for(const auto& dir : directories){
         if(!dir.exists()) {
-            DEB << dir << "Does not exist. Creating: " << dir.absolutePath();
+            DEB << dir << "Does not exist. Creating:" << dir.absolutePath();
             if (!dir.mkpath(dir.absolutePath()))
                 return false;
         }

--- a/src/classes/astandardpaths.h
+++ b/src/classes/astandardpaths.h
@@ -18,10 +18,10 @@ public:
     enum Directories {
         Database,
         Templates,
-        DatabaseBackup
+        Backup
     };
 private:
-    static QMap<Directories, QString> directories;
+    static QMap<Directories, QDir> directories;
 public:
     /// Initialise paths with corresponding StandardLocation paths
     static void setup();
@@ -30,14 +30,11 @@ public:
     // We should move away from getThis getThat functions.
     // I believe we can give better namings while avoiding this
     // OOP cliche of getEverything
-    static const QString& absPathOf(Directories loc);
-    static const QMap<Directories, QString>& allPaths();
+    static const QDir &directory(Directories loc);
+    static const QMap<Directories, QDir> &allDirectories();
 
     /// Ensure standard app directories exist, if not mkpath them.
-    static void scan_dirs();
-
-    /// Validate standard app directories are valid in structure and contents.
-    static bool validate_dirs();
+    static bool scan_dirs();
 };
 
 

--- a/src/classes/astandardpaths.h
+++ b/src/classes/astandardpaths.h
@@ -10,18 +10,18 @@
 /*!
  * \brief The AStandardAppPaths class encapsulates a static QMap holding
  * the standard paths of the application. Setup should be called after
- * `QCoreApplication::setWhateverName`.
+ * `QCoreApplication::setWhateverName`. The paths contained in this class
+ * include a trailing seperator and all seperators are platform-agnostic.
  */
 class AStandardPaths{
 public:
-    enum Dirs {
+    enum Directories {
         Database,
         Templates,
-        Settings,
         DatabaseBackup
     };
 private:
-    static QMap<Dirs, QString> dirs;
+    static QMap<Directories, QString> directories;
 public:
     /// Initialise paths with corresponding StandardLocation paths
     static void setup();
@@ -30,8 +30,8 @@ public:
     // We should move away from getThis getThat functions.
     // I believe we can give better namings while avoiding this
     // OOP cliche of getEverything
-    static const QString& absPathOf(Dirs loc);
-    static const QMap<Dirs, QString>& allPaths();
+    static const QString& absPathOf(Directories loc);
+    static const QMap<Directories, QString>& allPaths();
 
     /// Ensure standard app directories exist, if not mkpath them.
     static void scan_dirs();

--- a/src/classes/astandardpaths.h
+++ b/src/classes/astandardpaths.h
@@ -1,3 +1,20 @@
+/*
+ *openPilot Log - A FOSS Pilot Logbook Application
+ *Copyright (C) 2020  Felix Turowsky
+ *
+ *This program is free software: you can redistribute it and/or modify
+ *it under the terms of the GNU General Public License as published by
+ *the Free Software Foundation, either version 3 of the License, or
+ *(at your option) any later version.
+ *
+ *This program is distributed in the hope that it will be useful,
+ *but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *GNU General Public License for more details.
+ *
+ *You should have received a copy of the GNU General Public License
+ *along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 #ifndef ASTANDARDPATHS_H
 #define ASTANDARDPATHS_H
 
@@ -9,9 +26,7 @@
 
 /*!
  * \brief The AStandardAppPaths class encapsulates a static QMap holding
- * the standard paths of the application. Setup should be called after
- * `QCoreApplication::setWhateverName`. The paths contained in this class
- * include a trailing seperator and all seperators are platform-agnostic.
+ * the standard paths of the application.
  */
 class AStandardPaths{
 public:
@@ -22,19 +37,30 @@ public:
     };
 private:
     static QMap<Directories, QDir> directories;
+
+    /*!
+     * \brief Ensures the standard app directories exists and creates
+     * them if neccessary.
+     */
+    static bool scan_directories();
+
 public:
-    /// Initialise paths with corresponding StandardLocation paths
-    static void setup();
+    /*!
+     * \brief Creates and verifies a static map of the standard paths used in the app.
+     */
+    static bool setup();
 
-    // [G]: Subjective opinion:
-    // We should move away from getThis getThat functions.
-    // I believe we can give better namings while avoiding this
-    // OOP cliche of getEverything
-    static const QDir &directory(Directories loc);
+    /*!
+     * \brief Returns the QDir for the standard directory referenced
+     * by the Directories enum 'loc'
+     */
+    static const QDir &directory(Directories location);
+
+    /*!
+     * \brief returns the static map of all standard directories
+     * \return static const QMap<Directories, QDir>
+     */
     static const QMap<Directories, QDir> &allDirectories();
-
-    /// Ensure standard app directories exist, if not mkpath them.
-    static bool scan_dirs();
 };
 
 

--- a/src/classes/astyle.cpp
+++ b/src/classes/astyle.cpp
@@ -1,3 +1,20 @@
+/*
+ *openPilot Log - A FOSS Pilot Logbook Application
+ *Copyright (C) 2020  Felix Turowsky
+ *
+ *This program is free software: you can redistribute it and/or modify
+ *it under the terms of the GNU General Public License as published by
+ *the Free Software Foundation, either version 3 of the License, or
+ *(at your option) any later version.
+ *
+ *This program is distributed in the hope that it will be useful,
+ *but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *GNU General Public License for more details.
+ *
+ *You should have received a copy of the GNU General Public License
+ *along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 #include "astyle.h"
 #include <QStyle>
 #include <QStyleFactory>

--- a/src/classes/astyle.h
+++ b/src/classes/astyle.h
@@ -1,3 +1,20 @@
+/*
+ *openPilot Log - A FOSS Pilot Logbook Application
+ *Copyright (C) 2020  Felix Turowsky
+ *
+ *This program is free software: you can redistribute it and/or modify
+ *it under the terms of the GNU General Public License as published by
+ *the Free Software Foundation, either version 3 of the License, or
+ *(at your option) any later version.
+ *
+ *This program is distributed in the hope that it will be useful,
+ *but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *GNU General Public License for more details.
+ *
+ *You should have received a copy of the GNU General Public License
+ *along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 #ifndef ASTYLE_H
 #define ASTYLE_H
 #include <QString>

--- a/src/database/adatabase.cpp
+++ b/src/database/adatabase.cpp
@@ -81,8 +81,8 @@ ADatabase* ADatabase::instance()
 }
 
 ADatabase::ADatabase()
-    : databaseDir(QDir(AStandardPaths::absPathOf(AStandardPaths::Database))),
-      databaseFile(QFileInfo(databaseDir.filePath(QStringLiteral("logbook.db"))))
+    : databaseFile(QFileInfo(AStandardPaths::directory(AStandardPaths::Database).
+                             absoluteFilePath(QStringLiteral("logbook.db"))))
 {}
 
 /*!
@@ -101,6 +101,9 @@ const QString ADatabase::sqliteVersion()
 bool ADatabase::connect()
 {
     if (!QSqlDatabase::isDriverAvailable(SQLITE_DRIVER))
+        return false;
+
+    if (!databaseFile.exists())
         return false;
 
     QSqlDatabase db = QSqlDatabase::addDatabase(SQLITE_DRIVER);

--- a/src/database/adatabase.cpp
+++ b/src/database/adatabase.cpp
@@ -103,9 +103,6 @@ bool ADatabase::connect()
     if (!QSqlDatabase::isDriverAvailable(SQLITE_DRIVER))
         return false;
 
-    if (!databaseFile.exists())
-        return false;
-
     QSqlDatabase db = QSqlDatabase::addDatabase(SQLITE_DRIVER);
     db.setDatabaseName(databaseFile.absoluteFilePath());
 

--- a/src/database/adatabase.h
+++ b/src/database/adatabase.h
@@ -105,8 +105,9 @@ public:
     const QString sqliteVersion();
 
     ADatabaseError lastError;
-    const QDir databaseDir;
+    //const QDir databaseDir;
     const QFileInfo databaseFile;
+
 
     /*!
      * \brief Connect to the database and populate database information.

--- a/src/database/adatabasesetup.h
+++ b/src/database/adatabasesetup.h
@@ -43,7 +43,7 @@ public:
 
     static bool fillTemplates();
 
-    static bool importDefaultData();
+    static bool importDefaultData(bool use_local_data);
 
     static bool resetToDefault();
 

--- a/src/database/declarations.h
+++ b/src/database/declarations.h
@@ -1,3 +1,20 @@
+/*
+ *openPilot Log - A FOSS Pilot Logbook Application
+ *Copyright (C) 2020  Felix Turowsky
+ *
+ *This program is free software: you can redistribute it and/or modify
+ *it under the terms of the GNU General Public License as published by
+ *the Free Software Foundation, either version 3 of the License, or
+ *(at your option) any later version.
+ *
+ *This program is distributed in the hope that it will be useful,
+ *but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *GNU General Public License for more details.
+ *
+ *You should have received a copy of the GNU General Public License
+ *along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 #ifndef DECLARATIONS_H
 #define DECLARATIONS_H
 

--- a/src/functions/acalc.cpp
+++ b/src/functions/acalc.cpp
@@ -1,3 +1,20 @@
+/*
+ *openPilot Log - A FOSS Pilot Logbook Application
+ *Copyright (C) 2020  Felix Turowsky
+ *
+ *This program is free software: you can redistribute it and/or modify
+ *it under the terms of the GNU General Public License as published by
+ *the Free Software Foundation, either version 3 of the License, or
+ *(at your option) any later version.
+ *
+ *This program is distributed in the hope that it will be useful,
+ *but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *GNU General Public License for more details.
+ *
+ *You should have received a copy of the GNU General Public License
+ *along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 #include "acalc.h"
 #include "src/testing/adebug.h"
 #include "src/database/adatabase.h"

--- a/src/functions/acalc.h
+++ b/src/functions/acalc.h
@@ -1,3 +1,20 @@
+/*
+ *openPilot Log - A FOSS Pilot Logbook Application
+ *Copyright (C) 2020  Felix Turowsky
+ *
+ *This program is free software: you can redistribute it and/or modify
+ *it under the terms of the GNU General Public License as published by
+ *the Free Software Foundation, either version 3 of the License, or
+ *(at your option) any later version.
+ *
+ *This program is distributed in the hope that it will be useful,
+ *but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *GNU General Public License for more details.
+ *
+ *You should have received a copy of the GNU General Public License
+ *along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 #ifndef ACALC_H
 #define ACALC_H
 

--- a/src/functions/adatetime.h
+++ b/src/functions/adatetime.h
@@ -1,3 +1,20 @@
+/*
+ *openPilot Log - A FOSS Pilot Logbook Application
+ *Copyright (C) 2020  Felix Turowsky
+ *
+ *This program is free software: you can redistribute it and/or modify
+ *it under the terms of the GNU General Public License as published by
+ *the Free Software Foundation, either version 3 of the License, or
+ *(at your option) any later version.
+ *
+ *This program is distributed in the hope that it will be useful,
+ *but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *GNU General Public License for more details.
+ *
+ *You should have received a copy of the GNU General Public License
+ *along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 #ifndef ADATETIME_H
 #define ADATETIME_H
 #include <QtCore>

--- a/src/functions/areadcsv.cpp
+++ b/src/functions/areadcsv.cpp
@@ -1,3 +1,20 @@
+/*
+ *openPilot Log - A FOSS Pilot Logbook Application
+ *Copyright (C) 2020  Felix Turowsky
+ *
+ *This program is free software: you can redistribute it and/or modify
+ *it under the terms of the GNU General Public License as published by
+ *the Free Software Foundation, either version 3 of the License, or
+ *(at your option) any later version.
+ *
+ *This program is distributed in the hope that it will be useful,
+ *but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *GNU General Public License for more details.
+ *
+ *You should have received a copy of the GNU General Public License
+ *along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 #include "areadcsv.h"
 
 /*!

--- a/src/functions/areadcsv.h
+++ b/src/functions/areadcsv.h
@@ -1,3 +1,20 @@
+/*
+ *openPilot Log - A FOSS Pilot Logbook Application
+ *Copyright (C) 2020  Felix Turowsky
+ *
+ *This program is free software: you can redistribute it and/or modify
+ *it under the terms of the GNU General Public License as published by
+ *the Free Software Foundation, either version 3 of the License, or
+ *(at your option) any later version.
+ *
+ *This program is distributed in the hope that it will be useful,
+ *but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *GNU General Public License for more details.
+ *
+ *You should have received a copy of the GNU General Public License
+ *along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 #ifndef AREADCSV_H
 #define AREADCSV_H
 

--- a/src/functions/atime.h
+++ b/src/functions/atime.h
@@ -1,3 +1,20 @@
+/*
+ *openPilot Log - A FOSS Pilot Logbook Application
+ *Copyright (C) 2020  Felix Turowsky
+ *
+ *This program is free software: you can redistribute it and/or modify
+ *it under the terms of the GNU General Public License as published by
+ *the Free Software Foundation, either version 3 of the License, or
+ *(at your option) any later version.
+ *
+ *This program is distributed in the hope that it will be useful,
+ *but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *GNU General Public License for more details.
+ *
+ *You should have received a copy of the GNU General Public License
+ *along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 #ifndef ATIME_H
 #define ATIME_H
 

--- a/src/gui/dialogues/firstrundialog.cpp
+++ b/src/gui/dialogues/firstrundialog.cpp
@@ -6,7 +6,6 @@
 #include "src/classes/apilotentry.h"
 #include "src/classes/adownload.h"
 #include "src/classes/asettings.h"
-#include "src/classes/astandardpaths.h"
 #include "src/oplconstants.h"
 #include <QErrorMessage>
 
@@ -79,7 +78,7 @@ bool FirstRunDialog::finish()
 {
 
     ASettings::write(ASettings::FlightLogging::Function, ui->functionComboBox->currentText());
-    ASettings::write(ASettings::FlightLogging::Approach, ui->approachComboBox->currentText());
+    ASettings::write(ASettings::FlightLogging::Approach, ui->approachComboBox->currentIndex());
     ASettings::write(ASettings::FlightLogging::NightLogging, ui->nightComboBox->currentIndex());
     ASettings::write(ASettings::FlightLogging::LogIFR, ui->rulesComboBox->currentIndex());
     ASettings::write(ASettings::FlightLogging::FlightNumberPrefix, ui->prefixLineEdit->text());

--- a/src/gui/dialogues/firstrundialog.cpp
+++ b/src/gui/dialogues/firstrundialog.cpp
@@ -1,3 +1,20 @@
+/*
+ *openPilot Log - A FOSS Pilot Logbook Application
+ *Copyright (C) 2020  Felix Turowsky
+ *
+ *This program is free software: you can redistribute it and/or modify
+ *it under the terms of the GNU General Public License as published by
+ *the Free Software Foundation, either version 3 of the License, or
+ *(at your option) any later version.
+ *
+ *This program is distributed in the hope that it will be useful,
+ *but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *GNU General Public License for more details.
+ *
+ *You should have received a copy of the GNU General Public License
+ *along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 #include "firstrundialog.h"
 #include "ui_firstrundialog.h"
 #include "src/testing/adebug.h"

--- a/src/gui/dialogues/firstrundialog.h
+++ b/src/gui/dialogues/firstrundialog.h
@@ -24,17 +24,13 @@ private slots:
 
     void on_nextPushButton_clicked();
 
-//    void on_themeGroup_toggled(int id);
-
 private:
     Ui::FirstRunDialog *ui;
-    // [G]: finish is the old signal.
-    // finishSetup does something with template of database which
-    // goes over my head but everything works for now. Better naming needed
 
     void reject() override;
     bool setupDatabase();
     bool finish();
+    bool useLocalTemplates;
 
 };
 

--- a/src/gui/dialogues/firstrundialog.h
+++ b/src/gui/dialogues/firstrundialog.h
@@ -1,3 +1,20 @@
+/*
+ *openPilot Log - A FOSS Pilot Logbook Application
+ *Copyright (C) 2020  Felix Turowsky
+ *
+ *This program is free software: you can redistribute it and/or modify
+ *it under the terms of the GNU General Public License as published by
+ *the Free Software Foundation, either version 3 of the License, or
+ *(at your option) any later version.
+ *
+ *This program is distributed in the hope that it will be useful,
+ *but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *GNU General Public License for more details.
+ *
+ *You should have received a copy of the GNU General Public License
+ *along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 #ifndef FIRSTRUNDIALOG_H
 #define FIRSTRUNDIALOG_H
 

--- a/src/gui/dialogues/newflightdialog.cpp
+++ b/src/gui/dialogues/newflightdialog.cpp
@@ -155,7 +155,7 @@ void NewFlightDialog::readSettings()
     DEB << "Reading Settings...";
     QSettings settings;
     ui->FunctionComboBox->setCurrentText(ASettings::read(ASettings::FlightLogging::Function).toString());
-    ui->ApproachComboBox->setCurrentText(ASettings::read(ASettings::FlightLogging::Approach).toString());
+    ui->ApproachComboBox->setCurrentIndex(ASettings::read(ASettings::FlightLogging::Approach).toInt());
 
     ASettings::read(ASettings::FlightLogging::PilotFlying).toBool() ? ui->PilotFlyingCheckBox->setChecked(true)
                                                           : ui->PilotMonitoringCheckBox->setChecked(true);
@@ -189,7 +189,7 @@ void NewFlightDialog::writeSettings()
     DEB << "Writing Settings...";
 
     ASettings::write(ASettings::FlightLogging::Function, ui->FunctionComboBox->currentText());
-    ASettings::write(ASettings::FlightLogging::Approach, ui->ApproachComboBox->currentText());
+    ASettings::write(ASettings::FlightLogging::Approach, ui->ApproachComboBox->currentIndex());
     ASettings::write(ASettings::FlightLogging::PilotFlying, ui->PilotFlyingCheckBox->isChecked());
     ASettings::write(ASettings::FlightLogging::NumberTakeoffs, ui->TakeoffSpinBox->value());
     ASettings::write(ASettings::FlightLogging::NumberLandings, ui->LandingSpinBox->value());

--- a/src/gui/widgets/debugwidget.cpp
+++ b/src/gui/widgets/debugwidget.cpp
@@ -1,3 +1,20 @@
+/*
+ *openPilot Log - A FOSS Pilot Logbook Application
+ *Copyright (C) 2020  Felix Turowsky
+ *
+ *This program is free software: you can redistribute it and/or modify
+ *it under the terms of the GNU General Public License as published by
+ *the Free Software Foundation, either version 3 of the License, or
+ *(at your option) any later version.
+ *
+ *This program is distributed in the hope that it will be useful,
+ *but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *GNU General Public License for more details.
+ *
+ *You should have received a copy of the GNU General Public License
+ *along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 #include "debugwidget.h"
 #include "ui_debugwidget.h"
 #include "src/classes/astandardpaths.h"
@@ -145,7 +162,7 @@ void DebugWidget::on_importCsvPushButton_clicked()
 {
     ATimer timer(this);
     auto file = QFileInfo(ui->importCsvLineEdit->text());
-    DEB << "File exists/is file: " << file.exists() << file.isFile() << " Path: " << file.absoluteFilePath();
+    DEB << "File exists/is file:" << file.exists() << file.isFile() << " Path:" << file.absoluteFilePath();
 
     if (file.exists() && file.isFile()) {
 
@@ -169,8 +186,6 @@ void DebugWidget::on_debugPushButton_clicked()
 {
     // debug space
     //ASettings::write(ASettings::Setup::SetupComplete, false);
-    ASettings::write(ASettings::FlightLogging::Approach, 5);
-    DEB << ASettings::read(ASettings::FlightLogging::Approach);
 
 }
 

--- a/src/gui/widgets/debugwidget.cpp
+++ b/src/gui/widgets/debugwidget.cpp
@@ -50,7 +50,7 @@ void DebugWidget::on_resetDatabasePushButton_clicked()
     link_stub.append("/assets/database/templates/");
 
     QStringList template_tables = {"aircraft", "airports", "changelog"};
-    QDir template_dir(AStandardPaths::absPathOf(AStandardPaths::Templates));
+    QDir template_dir(AStandardPaths::directory(AStandardPaths::Templates));
     for (const auto& table : template_tables) {
         QEventLoop loop;
         ADownload* dl = new ADownload;
@@ -100,7 +100,7 @@ void DebugWidget::on_fillUserDataPushButton_clicked()
     QString linkStub = "https://raw.githubusercontent.com/fiffty-50/openpilotlog/";
     linkStub.append(ui->branchLineEdit->text());
     linkStub.append("/assets/database/templates/sample_");
-    QDir template_dir(AStandardPaths::absPathOf(AStandardPaths::Templates));
+    QDir template_dir(AStandardPaths::directory(AStandardPaths::Templates));
 
     for (const auto& table : userTables) {
         QEventLoop loop;
@@ -116,8 +116,8 @@ void DebugWidget::on_fillUserDataPushButton_clicked()
     allGood.resize(userTables.size());
 
     for (const auto& table : userTables) {
-        auto data = aReadCsv(AStandardPaths::absPathOf(AStandardPaths::Templates)
-                             + "/sample_" + table + ".csv");
+        auto data = aReadCsv(AStandardPaths::directory(AStandardPaths::Templates).absoluteFilePath(
+                             + "sample_" + table + ".csv"));
         allGood.setBit(userTables.indexOf(table), ADataBaseSetup::commitData(data, table));
     }
 
@@ -136,7 +136,7 @@ void DebugWidget::on_selectCsvPushButton_clicked()
 {
     auto fileName = QFileDialog::getOpenFileName(this,
                                                  tr("Open CSV File for import"),
-                                                 AStandardPaths::absPathOf(AStandardPaths::Templates),
+                                                 AStandardPaths::directory(AStandardPaths::Templates).absolutePath(),
                                                  tr("CSV files (*.csv)"));
     ui->importCsvLineEdit->setText(fileName);
 }
@@ -168,7 +168,10 @@ void DebugWidget::on_importCsvPushButton_clicked()
 void DebugWidget::on_debugPushButton_clicked()
 {
     // debug space
-    ASettings::write(ASettings::Setup::SetupComplete, false);
+    //ASettings::write(ASettings::Setup::SetupComplete, false);
+    ASettings::write(ASettings::FlightLogging::Approach, 5);
+    DEB << ASettings::read(ASettings::FlightLogging::Approach);
+
 }
 
 /* //Comparing two functions template

--- a/src/gui/widgets/debugwidget.cpp
+++ b/src/gui/widgets/debugwidget.cpp
@@ -75,7 +75,7 @@ void DebugWidget::on_resetDatabasePushButton_clicked()
                             "Check console for details.");
         message_box.exec();
     }
-    if (ADataBaseSetup::importDefaultData()) {
+    if (ADataBaseSetup::importDefaultData(false)) {
         message_box.setText("Database has been successfully reset.");
         emit aDB->dataBaseUpdated();
         message_box.exec();
@@ -168,6 +168,7 @@ void DebugWidget::on_importCsvPushButton_clicked()
 void DebugWidget::on_debugPushButton_clicked()
 {
     // debug space
+    ASettings::write(ASettings::Setup::SetupComplete, false);
 }
 
 /* //Comparing two functions template

--- a/src/gui/widgets/debugwidget.h
+++ b/src/gui/widgets/debugwidget.h
@@ -1,3 +1,20 @@
+/*
+ *openPilot Log - A FOSS Pilot Logbook Application
+ *Copyright (C) 2020  Felix Turowsky
+ *
+ *This program is free software: you can redistribute it and/or modify
+ *it under the terms of the GNU General Public License as published by
+ *the Free Software Foundation, either version 3 of the License, or
+ *(at your option) any later version.
+ *
+ *This program is distributed in the hope that it will be useful,
+ *but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *GNU General Public License for more details.
+ *
+ *You should have received a copy of the GNU General Public License
+ *along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 #ifndef DEBUGWIDGET_H
 #define DEBUGWIDGET_H
 

--- a/src/gui/widgets/totalswidget.cpp
+++ b/src/gui/widgets/totalswidget.cpp
@@ -1,3 +1,20 @@
+/*
+ *openPilot Log - A FOSS Pilot Logbook Application
+ *Copyright (C) 2020  Felix Turowsky
+ *
+ *This program is free software: you can redistribute it and/or modify
+ *it under the terms of the GNU General Public License as published by
+ *the Free Software Foundation, either version 3 of the License, or
+ *(at your option) any later version.
+ *
+ *This program is distributed in the hope that it will be useful,
+ *but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *GNU General Public License for more details.
+ *
+ *You should have received a copy of the GNU General Public License
+ *along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 #include "totalswidget.h"
 #include "ui_totalswidget.h"
 #include "src/testing/adebug.h"

--- a/src/gui/widgets/totalswidget.h
+++ b/src/gui/widgets/totalswidget.h
@@ -1,3 +1,20 @@
+/*
+ *openPilot Log - A FOSS Pilot Logbook Application
+ *Copyright (C) 2020  Felix Turowsky
+ *
+ *This program is free software: you can redistribute it and/or modify
+ *it under the terms of the GNU General Public License as published by
+ *the Free Software Foundation, either version 3 of the License, or
+ *(at your option) any later version.
+ *
+ *This program is distributed in the hope that it will be useful,
+ *but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *GNU General Public License for more details.
+ *
+ *You should have received a copy of the GNU General Public License
+ *along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 #ifndef TOTALSWIDGET_H
 #define TOTALSWIDGET_H
 

--- a/src/oplconstants.h
+++ b/src/oplconstants.h
@@ -1,3 +1,20 @@
+/*
+ *openPilot Log - A FOSS Pilot Logbook Application
+ *Copyright (C) 2020  Felix Turowsky
+ *
+ *This program is free software: you can redistribute it and/or modify
+ *it under the terms of the GNU General Public License as published by
+ *the Free Software Foundation, either version 3 of the License, or
+ *(at your option) any later version.
+ *
+ *This program is distributed in the hope that it will be useful,
+ *but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *GNU General Public License for more details.
+ *
+ *You should have received a copy of the GNU General Public License
+ *along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 #ifndef OPLCONSTANTS_H
 #define OPLCONSTANTS_H
 


### PR DESCRIPTION
The templates that are used to create the initial database are now included in the project itself. This enables the user to choose not to download the latest revision should there be connectivity issues.

Even if the user chooses to download the latest templates, there is now a fallback mechanism to create the database from local data, in case the download fails. This leaves the user with a working application instead of being stuck at the FirstRunDialog.

Creating the database layout has been decoupled from filling in the template data.

This commit closes #52 