### PR TITLE
Refactor of mandatoryLineEdits

### DIFF
--- a/src/gui/dialogues/newflightdialog.cpp
+++ b/src/gui/dialogues/newflightdialog.cpp
@@ -57,7 +57,15 @@ static const auto MANDATORY_LINE_EDITS_DISPLAY_NAMES = QMap<int, QString> {
 
 //
 // MandatoryLineEdits definition
-//
+// Ugly but works
+NewFlightDialog::MandatoryLineEdits::MandatoryLineEdits(std::initializer_list<QLineEdit*> il)
+    : lineEdits(il), lineEditsOk(il.size())
+{}
+void NewFlightDialog::MandatoryLineEdits::operator= (std::initializer_list<QLineEdit*> il)
+{
+    lineEdits = il;
+    lineEdits.resize(il.size());
+}
 bool NewFlightDialog::MandatoryLineEdits::contains(QLineEdit* le)
 {
     return lineEdits.contains(le);
@@ -290,7 +298,7 @@ void NewFlightDialog::setupRawInputValidation()
 
     // [G]: TODO cleanup
     // populate Mandatory Line Edits list and prepare QBitArray
-    mandatoryLineEdits.lineEdits = {
+    mandatoryLineEdits = {
         ui->doftLineEdit,
         ui->deptLocLineEdit,
         ui->destLocLineEdit,
@@ -299,7 +307,6 @@ void NewFlightDialog::setupRawInputValidation()
         ui->picNameLineEdit,
         ui->acftLineEdit,
     };
-    mandatoryLineEdits.lineEditsOk.resize(mandatoryLineEdits.lineEdits.size());
 
     primaryTimeLineEdits = {
         ui->tofbTimeLineEdit,

--- a/src/gui/dialogues/newflightdialog.h
+++ b/src/gui/dialogues/newflightdialog.h
@@ -93,9 +93,17 @@ private:
     AFlightEntry flightEntry;
 
     // [G]: Initial refactoring based on previous use.
+    /*!
+     * \brief Wrapper around Vector of mandatory line edits and their corresponding
+     * "ok" QBitArray.
+     */
     struct MandatoryLineEdits {
         QVector<QLineEdit*> lineEdits;
         QBitArray lineEditsOk;
+
+        MandatoryLineEdits() = default;
+        MandatoryLineEdits(std::initializer_list<QLineEdit*> il);
+        void operator= (std::initializer_list<QLineEdit*> il);
 
         bool contains(QLineEdit* le);
         void validate(QLineEdit* le);
@@ -105,15 +113,11 @@ private:
         bool okAt(int idx);
         bool allOk();
         QLineEdit* operator[] (int idx);
+
     } mandatoryLineEdits;
 
     QList<QLineEdit*> primaryTimeLineEdits;
     QList<QLineEdit*> pilotsLineEdits;
-
-    /*!
-     * \brief holds a bit for each mandatory line edit that is flipped
-     * according to its validity state
-     */
 
     /*!
      * To be used by the QCompleters

--- a/src/gui/dialogues/newflightdialog.h
+++ b/src/gui/dialogues/newflightdialog.h
@@ -92,7 +92,21 @@ private:
      */
     AFlightEntry flightEntry;
 
-    QList<QLineEdit*> mandatoryLineEdits;
+    // [G]: Initial refactoring based on previous use.
+    struct MandatoryLineEdits {
+        QVector<QLineEdit*> lineEdits;
+        QBitArray lineEditsOk;
+
+        bool contains(QLineEdit* le);
+        void validate(QLineEdit* le);
+        void unvalidate(QLineEdit* le);
+        int countOk();
+        int size();
+        bool okAt(int idx);
+        bool allOk();
+        QLineEdit* operator[] (int idx);
+    } mandatoryLineEdits;
+
     QList<QLineEdit*> primaryTimeLineEdits;
     QList<QLineEdit*> pilotsLineEdits;
 
@@ -100,7 +114,6 @@ private:
      * \brief holds a bit for each mandatory line edit that is flipped
      * according to its validity state
      */
-    QBitArray mandatoryLineEditsGood;
 
     /*!
      * To be used by the QCompleters

--- a/src/gui/dialogues/newflightdialog.h
+++ b/src/gui/dialogues/newflightdialog.h
@@ -99,25 +99,25 @@ private:
      */
     struct MandatoryLineEdits {
         QVector<QLineEdit*> lineEdits;
-        QBitArray lineEditsOk;
+        QBitArray lineEditsValid;
 
         MandatoryLineEdits() = default;
-        MandatoryLineEdits(std::initializer_list<QLineEdit*> il);
-        void operator= (std::initializer_list<QLineEdit*> il);
+        MandatoryLineEdits(std::initializer_list<QLineEdit*> init_list);
+        void operator= (std::initializer_list<QLineEdit*> init_list);
 
-        bool contains(QLineEdit* le);
-        void validate(QLineEdit* le);
-        void unvalidate(QLineEdit* le);
-        int countOk();
+        bool contains(QLineEdit* line_edit);
+        void validate(QLineEdit* line_edit);
+        void unvalidate(QLineEdit* line_edit);
+        int countValid();
         int size();
-        bool okAt(int idx);
-        bool allOk();
+        bool validAt(int idx);
+        bool allValid();
         QLineEdit* operator[] (int idx);
 
     } mandatoryLineEdits;
 
-    QList<QLineEdit*> primaryTimeLineEdits;
-    QList<QLineEdit*> pilotsLineEdits;
+    QVector<QLineEdit*> primaryTimeLineEdits;
+    QVector<QLineEdit*> pilotsLineEdits;
 
     /*!
      * To be used by the QCompleters


### PR DESCRIPTION
closes #59

Steamlining lineedit encapsulation in NewFlightDialog.
Mandatory line edits and "ok" QBitArray encapsulated in nested struct.

Further refactoring will include giving semantic value to bare types such as int or QString.