### PR TITLE
Initial draft or giving semantics to raw QStrings and ints.

### DIFF
--- a/openPilotLog.pro
+++ b/openPilotLog.pro
@@ -63,7 +63,7 @@ HEADERS += \
     src/classes/atailentry.h \
     src/database/adatabase.h \
     src/database/adatabasesetup.h \
-    src/database/declarations.h \
+    src/database/adatabasetypes.h \
     src/functions/acalc.h \
     src/functions/adatetime.h \
     src/functions/areadcsv.h \

--- a/src/classes/aaircraftentry.cpp
+++ b/src/classes/aaircraftentry.cpp
@@ -19,13 +19,13 @@
 #include "src/oplconstants.h"
 
 AAircraftEntry::AAircraftEntry()
-    : AEntry::AEntry(DEFAULT_AIRCRAFT_POSITION)
+    : AEntry::AEntry(Opl::Db::DEFAULT_AIRCRAFT_POSITION)
 {}
 
-AAircraftEntry::AAircraftEntry(RowId row_id)
+AAircraftEntry::AAircraftEntry(RowId_t row_id)
     : AEntry::AEntry(DataPosition(Opl::Db::TABLE_AIRCRAFT, row_id))
 {}
 
-AAircraftEntry::AAircraftEntry(RowData table_data)
-    : AEntry::AEntry(DEFAULT_AIRCRAFT_POSITION, table_data)
+AAircraftEntry::AAircraftEntry(RowData_t table_data)
+    : AEntry::AEntry(Opl::Db::DEFAULT_AIRCRAFT_POSITION, table_data)
 {}

--- a/src/classes/aaircraftentry.cpp
+++ b/src/classes/aaircraftentry.cpp
@@ -22,10 +22,10 @@ AAircraftEntry::AAircraftEntry()
     : AEntry::AEntry(Opl::Db::DEFAULT_AIRCRAFT_POSITION)
 {}
 
-AAircraftEntry::AAircraftEntry(RowId_t row_id)
+AAircraftEntry::AAircraftEntry(RowId_T row_id)
     : AEntry::AEntry(DataPosition(Opl::Db::TABLE_AIRCRAFT, row_id))
 {}
 
-AAircraftEntry::AAircraftEntry(RowData_t table_data)
+AAircraftEntry::AAircraftEntry(RowData_T table_data)
     : AEntry::AEntry(Opl::Db::DEFAULT_AIRCRAFT_POSITION, table_data)
 {}

--- a/src/classes/aaircraftentry.h
+++ b/src/classes/aaircraftentry.h
@@ -19,13 +19,13 @@
 #define AAIRCRAFTENTRY_H
 
 #include "src/classes/aentry.h"
-#include "src/database/declarations.h"
+#include "src/database/adatabasetypes.h"
 
 struct AAircraftEntry : public AEntry {
 public:
     AAircraftEntry();
-    AAircraftEntry(RowId row_id);
-    AAircraftEntry(RowData table_data);
+    AAircraftEntry(RowId_t row_id);
+    AAircraftEntry(RowData_t table_data);
 
     AAircraftEntry(const AAircraftEntry& te) = default;
     AAircraftEntry& operator=(const AAircraftEntry& te) = default;

--- a/src/classes/aaircraftentry.h
+++ b/src/classes/aaircraftentry.h
@@ -24,8 +24,8 @@
 struct AAircraftEntry : public AEntry {
 public:
     AAircraftEntry();
-    AAircraftEntry(RowId_t row_id);
-    AAircraftEntry(RowData_t table_data);
+    AAircraftEntry(RowId_T row_id);
+    AAircraftEntry(RowData_T table_data);
 
     AAircraftEntry(const AAircraftEntry& te) = default;
     AAircraftEntry& operator=(const AAircraftEntry& te) = default;

--- a/src/classes/aentry.cpp
+++ b/src/classes/aentry.cpp
@@ -21,15 +21,15 @@ AEntry::AEntry(DataPosition position_)
     : position(position_)
 {}
 
-AEntry::AEntry(RowData_t table_data)
+AEntry::AEntry(RowData_T table_data)
     : tableData(table_data)
 {}
 
-AEntry::AEntry(DataPosition position_, RowData_t table_data)
+AEntry::AEntry(DataPosition position_, RowData_T table_data)
     : position(position_), tableData(table_data)
 {}
 
-void AEntry::setData(RowData_t table_data)
+void AEntry::setData(RowData_T table_data)
 {
     tableData = table_data;
 }
@@ -39,7 +39,7 @@ const DataPosition& AEntry::getPosition()
     return position;
 }
 
-const RowData_t& AEntry::getData()
+const RowData_T& AEntry::getData()
 {
     return tableData;
 }

--- a/src/classes/aentry.cpp
+++ b/src/classes/aentry.cpp
@@ -21,15 +21,15 @@ AEntry::AEntry(DataPosition position_)
     : position(position_)
 {}
 
-AEntry::AEntry(RowData table_data)
+AEntry::AEntry(RowData_t table_data)
     : tableData(table_data)
 {}
 
-AEntry::AEntry(DataPosition position_, RowData table_data)
+AEntry::AEntry(DataPosition position_, RowData_t table_data)
     : position(position_), tableData(table_data)
 {}
 
-void AEntry::setData(RowData table_data)
+void AEntry::setData(RowData_t table_data)
 {
     tableData = table_data;
 }
@@ -39,7 +39,7 @@ const DataPosition& AEntry::getPosition()
     return position;
 }
 
-const RowData& AEntry::getData()
+const RowData_t& AEntry::getData()
 {
     return tableData;
 }

--- a/src/classes/aentry.h
+++ b/src/classes/aentry.h
@@ -24,7 +24,7 @@
 #include <QPair>
 #include <QVariant>
 
-#include "src/database/declarations.h"
+#include "src/database/adatabasetypes.h"
 
 // [G]: Define what data is public and what not. For objects such as
 // DataPosition which are consumable its no biggy. Are entries the same?
@@ -41,20 +41,20 @@ class AEntry {
 protected:
     DataPosition position;
 public:
-    RowData tableData;
+    RowData_t tableData;
 public:
     AEntry() = delete; // Demand specificity from default constructor
     AEntry(const AEntry&) = default;
     AEntry& operator=(const AEntry&) = default;
     AEntry(DataPosition position_);
-    AEntry(RowData table_data);
-    AEntry(DataPosition position_, RowData table_data);
+    AEntry(RowData_t table_data);
+    AEntry(DataPosition position_, RowData_t table_data);
 
-    void setData(RowData table_data);
+    void setData(RowData_t table_data);
     void setPosition(DataPosition position_);
 
     const DataPosition& getPosition();
-    const RowData& getData();
+    const RowData_t& getData();
 
 };
 

--- a/src/classes/aentry.h
+++ b/src/classes/aentry.h
@@ -41,20 +41,20 @@ class AEntry {
 protected:
     DataPosition position;
 public:
-    RowData_t tableData;
+    RowData_T tableData;
 public:
     AEntry() = delete; // Demand specificity from default constructor
     AEntry(const AEntry&) = default;
     AEntry& operator=(const AEntry&) = default;
     AEntry(DataPosition position_);
-    AEntry(RowData_t table_data);
-    AEntry(DataPosition position_, RowData_t table_data);
+    AEntry(RowData_T table_data);
+    AEntry(DataPosition position_, RowData_T table_data);
 
-    void setData(RowData_t table_data);
+    void setData(RowData_T table_data);
     void setPosition(DataPosition position_);
 
     const DataPosition& getPosition();
-    const RowData_t& getData();
+    const RowData_T& getData();
 
 };
 

--- a/src/classes/aflightentry.cpp
+++ b/src/classes/aflightentry.cpp
@@ -22,15 +22,15 @@
 #include "src/classes/asettings.h"
 
 AFlightEntry::AFlightEntry()
-    : AEntry::AEntry(DEFAULT_FLIGHT_POSITION)
+    : AEntry::AEntry(Opl::Db::DEFAULT_FLIGHT_POSITION)
 {}
 
-AFlightEntry::AFlightEntry(RowId row_id)
+AFlightEntry::AFlightEntry(RowId_t row_id)
     : AEntry::AEntry(DataPosition(Opl::Db::TABLE_FLIGHTS, row_id))
 {}
 
-AFlightEntry::AFlightEntry(RowData table_data)
-    : AEntry::AEntry(DEFAULT_FLIGHT_POSITION, table_data)
+AFlightEntry::AFlightEntry(RowData_t table_data)
+    : AEntry::AEntry(Opl::Db::DEFAULT_FLIGHT_POSITION, table_data)
 {}
 
 const QString AFlightEntry::summary()

--- a/src/classes/aflightentry.cpp
+++ b/src/classes/aflightentry.cpp
@@ -25,11 +25,11 @@ AFlightEntry::AFlightEntry()
     : AEntry::AEntry(Opl::Db::DEFAULT_FLIGHT_POSITION)
 {}
 
-AFlightEntry::AFlightEntry(RowId_t row_id)
+AFlightEntry::AFlightEntry(RowId_T row_id)
     : AEntry::AEntry(DataPosition(Opl::Db::TABLE_FLIGHTS, row_id))
 {}
 
-AFlightEntry::AFlightEntry(RowData_t table_data)
+AFlightEntry::AFlightEntry(RowData_T table_data)
     : AEntry::AEntry(Opl::Db::DEFAULT_FLIGHT_POSITION, table_data)
 {}
 

--- a/src/classes/aflightentry.h
+++ b/src/classes/aflightentry.h
@@ -23,8 +23,8 @@
 class AFlightEntry : public AEntry {
 public:
     AFlightEntry();
-    AFlightEntry(RowId row_id);
-    AFlightEntry(RowData table_data);
+    AFlightEntry(RowId_t row_id);
+    AFlightEntry(RowData_t table_data);
 
     AFlightEntry(const AFlightEntry& pe) = default;
     AFlightEntry& operator=(const AFlightEntry& pe) = default;

--- a/src/classes/aflightentry.h
+++ b/src/classes/aflightentry.h
@@ -23,8 +23,8 @@
 class AFlightEntry : public AEntry {
 public:
     AFlightEntry();
-    AFlightEntry(RowId_t row_id);
-    AFlightEntry(RowData_t table_data);
+    AFlightEntry(RowId_T row_id);
+    AFlightEntry(RowData_T table_data);
 
     AFlightEntry(const AFlightEntry& pe) = default;
     AFlightEntry& operator=(const AFlightEntry& pe) = default;

--- a/src/classes/apilotentry.cpp
+++ b/src/classes/apilotentry.cpp
@@ -22,11 +22,11 @@ APilotEntry::APilotEntry()
     : AEntry::AEntry(Opl::Db::DEFAULT_PILOT_POSITION)
 {}
 
-APilotEntry::APilotEntry(RowId_t row_id)
+APilotEntry::APilotEntry(RowId_T row_id)
     : AEntry::AEntry(DataPosition(Opl::Db::TABLE_PILOTS, row_id))
 {}
 
-APilotEntry::APilotEntry(RowData_t table_data)
+APilotEntry::APilotEntry(RowData_T table_data)
     : AEntry::AEntry(Opl::Db::DEFAULT_PILOT_POSITION, table_data)
 {}
 

--- a/src/classes/apilotentry.cpp
+++ b/src/classes/apilotentry.cpp
@@ -19,15 +19,15 @@
 #include "src/oplconstants.h"
 
 APilotEntry::APilotEntry()
-    : AEntry::AEntry(DEFAULT_PILOT_POSITION)
+    : AEntry::AEntry(Opl::Db::DEFAULT_PILOT_POSITION)
 {}
 
-APilotEntry::APilotEntry(RowId row_id)
+APilotEntry::APilotEntry(RowId_t row_id)
     : AEntry::AEntry(DataPosition(Opl::Db::TABLE_PILOTS, row_id))
 {}
 
-APilotEntry::APilotEntry(RowData table_data)
-    : AEntry::AEntry(DEFAULT_PILOT_POSITION, table_data)
+APilotEntry::APilotEntry(RowData_t table_data)
+    : AEntry::AEntry(Opl::Db::DEFAULT_PILOT_POSITION, table_data)
 {}
 
 const QString APilotEntry::name()

--- a/src/classes/apilotentry.h
+++ b/src/classes/apilotentry.h
@@ -24,8 +24,8 @@
 struct APilotEntry : public AEntry {
 public:
     APilotEntry();
-    APilotEntry(RowId_t row_id);
-    APilotEntry(RowData_t table_data);
+    APilotEntry(RowId_T row_id);
+    APilotEntry(RowData_T table_data);
 
     APilotEntry(const APilotEntry& pe) = default;
     APilotEntry& operator=(const APilotEntry& pe) = default;

--- a/src/classes/apilotentry.h
+++ b/src/classes/apilotentry.h
@@ -19,13 +19,13 @@
 #define APILOTENTRY_H
 
 #include "src/classes/aentry.h"
-#include "src/database/declarations.h"
+#include "src/database/adatabasetypes.h"
 
 struct APilotEntry : public AEntry {
 public:
     APilotEntry();
-    APilotEntry(RowId row_id);
-    APilotEntry(RowData table_data);
+    APilotEntry(RowId_t row_id);
+    APilotEntry(RowData_t table_data);
 
     APilotEntry(const APilotEntry& pe) = default;
     APilotEntry& operator=(const APilotEntry& pe) = default;

--- a/src/classes/atailentry.cpp
+++ b/src/classes/atailentry.cpp
@@ -22,11 +22,11 @@ ATailEntry::ATailEntry()
     : AEntry::AEntry(Opl::Db::DEFAULT_TAIL_POSITION)
 {}
 
-ATailEntry::ATailEntry(RowId_t row_id)
+ATailEntry::ATailEntry(RowId_T row_id)
     : AEntry::AEntry(DataPosition(Opl::Db::TABLE_TAILS, row_id))
 {}
 
-ATailEntry::ATailEntry(RowData_t table_data)
+ATailEntry::ATailEntry(RowData_T table_data)
     : AEntry::AEntry(Opl::Db::DEFAULT_TAIL_POSITION, table_data)
 {}
 

--- a/src/classes/atailentry.cpp
+++ b/src/classes/atailentry.cpp
@@ -19,15 +19,15 @@
 #include "src/oplconstants.h"
 
 ATailEntry::ATailEntry()
-    : AEntry::AEntry(DEFAULT_TAIL_POSITION)
+    : AEntry::AEntry(Opl::Db::DEFAULT_TAIL_POSITION)
 {}
 
-ATailEntry::ATailEntry(RowId row_id)
+ATailEntry::ATailEntry(RowId_t row_id)
     : AEntry::AEntry(DataPosition(Opl::Db::TABLE_TAILS, row_id))
 {}
 
-ATailEntry::ATailEntry(RowData table_data)
-    : AEntry::AEntry(DEFAULT_TAIL_POSITION, table_data)
+ATailEntry::ATailEntry(RowData_t table_data)
+    : AEntry::AEntry(Opl::Db::DEFAULT_TAIL_POSITION, table_data)
 {}
 
 const QString ATailEntry::registration()

--- a/src/classes/atailentry.h
+++ b/src/classes/atailentry.h
@@ -26,8 +26,8 @@ public:
     ATailEntry();
     ATailEntry(const ATailEntry& te) = default;
     ATailEntry& operator=(const ATailEntry& te) = default;
-    ATailEntry(RowId_t row_id);
-    ATailEntry(RowData_t table_data);
+    ATailEntry(RowId_T row_id);
+    ATailEntry(RowData_T table_data);
 
     const QString registration();
 

--- a/src/classes/atailentry.h
+++ b/src/classes/atailentry.h
@@ -19,15 +19,15 @@
 #define ATAILENTRY_H
 
 #include "src/classes/aentry.h"
-#include "src/database/declarations.h"
+#include "src/database/adatabasetypes.h"
 
 struct ATailEntry : public AEntry {
 public:
     ATailEntry();
     ATailEntry(const ATailEntry& te) = default;
     ATailEntry& operator=(const ATailEntry& te) = default;
-    ATailEntry(RowId row_id);
-    ATailEntry(RowData table_data);
+    ATailEntry(RowId_t row_id);
+    ATailEntry(RowData_t table_data);
 
     const QString registration();
 

--- a/src/database/adatabase.cpp
+++ b/src/database/adatabase.cpp
@@ -497,7 +497,7 @@ const QStringList ADatabase::getCompletionList(ADatabaseTarget target)
 }
 
 const
-QMap<ADatabase::QueryResult_qstr, ADatabase::QueryResult_i> ADatabase::getIdMap(ADatabaseTarget target)
+QMap<ADatabase::QString, ADatabase::RowId_t> ADatabase::getIdMap(ADatabaseTarget target)
 {
     QString statement;
 
@@ -538,7 +538,7 @@ QMap<ADatabase::QueryResult_qstr, ADatabase::QueryResult_i> ADatabase::getIdMap(
     }
 
     // QVector<QString> query_result;  // [G]: unused
-    auto id_map = QMap<QueryResult_qstr, QueryResult_i>();
+    auto id_map = QMap<QString, RowId_t>();
     while (query.next()) {
         id_map.insert(query.value(1).toString(), query.value(0).toInt());
     }

--- a/src/database/adatabase.cpp
+++ b/src/database/adatabase.cpp
@@ -496,7 +496,8 @@ const QStringList ADatabase::getCompletionList(ADatabaseTarget target)
     return completer_list;
 }
 
-const QMap<QString, int> ADatabase::getIdMap(ADatabaseTarget target)
+const
+QMap<ADatabase::QueryResult_qstr, ADatabase::QueryResult_i> ADatabase::getIdMap(ADatabaseTarget target)
 {
     QString statement;
 
@@ -523,24 +524,25 @@ const QMap<QString, int> ADatabase::getIdMap(ADatabaseTarget target)
         break;
     default:
         DEB << "Not a valid completer target for this function.";
-        return QMap<QString, int>();
+        return {};  // [G]: Cpp will implicitly create the default map.
+                    // if this is too vague change to QMap<...>()
     }
 
-    auto id_map = QMap<QString, int>();
     auto query = QSqlQuery(statement);
     if (!query.isActive()) {
         DEB << "No result found. Check Query and Error.";
         DEB << "Query: " << statement;
         DEB << "Error: " << query.lastError().text();
         lastError = query.lastError().text();
-        return QMap<QString, int>();
-    } else {
-        QVector<QString> query_result;
-        while (query.next()) {
-            id_map.insert(query.value(1).toString(), query.value(0).toInt());
-        }
-        return id_map;
+        return {};
     }
+
+    // QVector<QString> query_result;  // [G]: unused
+    auto id_map = QMap<QueryResult_qstr, QueryResult_i>();
+    while (query.next()) {
+        id_map.insert(query.value(1).toString(), query.value(0).toInt());
+    }
+    return id_map;
 }
 
 int ADatabase::getLastEntry(ADatabaseTarget target)

--- a/src/database/adatabase.cpp
+++ b/src/database/adatabase.cpp
@@ -35,7 +35,7 @@ ADatabase* ADatabase::self = nullptr;
 /*!
  * \brief Return the names of a given table in the database.
  */
-ColumnNames_t ADatabase::getTableColumns(TableName_t table_name) const
+ColumnNames_T ADatabase::getTableColumns(TableName_T table_name) const
 {
     return tableColumns.value(table_name);
 }
@@ -43,7 +43,7 @@ ColumnNames_t ADatabase::getTableColumns(TableName_t table_name) const
 /*!
  * \brief Return the names of all tables in the database
  */
-TableNames_t ADatabase::getTableNames() const
+TableNames_T ADatabase::getTableNames() const
 {
     return tableNames;
 }
@@ -59,7 +59,7 @@ void ADatabase::updateLayout()
 
     tableColumns.clear();
     for (const auto &table_name : tableNames) {
-        ColumnNames_t table_columns;
+        ColumnNames_T table_columns;
         QSqlRecord fields = db.record(table_name);
         for (int i = 0; i < fields.count(); i++) {
             table_columns.append(fields.field(i).name());
@@ -356,12 +356,12 @@ bool ADatabase::insert(AEntry new_entry)
 
 }
 
-RowData_t ADatabase::getEntryData(DataPosition data_position)
+RowData_T ADatabase::getEntryData(DataPosition data_position)
 {
     // check table exists
     if (!getTableNames().contains(data_position.tableName)) {
         DEB << data_position.tableName << " not a table in the database. Unable to retreive Entry data.";
-        return RowData_t();
+        return RowData_T();
     }
 
     //Check Database for rowId
@@ -377,14 +377,14 @@ RowData_t ADatabase::getEntryData(DataPosition data_position)
         DEB << "SQL error: " << check_query.lastError().text();
         DEB << "Statement: " << statement;
         lastError = check_query.lastError().text();
-        return RowData_t();
+        return RowData_T();
     }
 
     check_query.next();
     if (check_query.value(0).toInt() == 0) {
         DEB << "No Entry found for row id: " << data_position.rowId;
         lastError = ADatabaseError("Database entry not found.");
-        return RowData_t();
+        return RowData_T();
     }
 
     // Retreive TableData
@@ -401,11 +401,11 @@ RowData_t ADatabase::getEntryData(DataPosition data_position)
         DEB << "SQL error: " << select_query.lastError().text();
         DEB << "Statement: " << statement;
         lastError = select_query.lastError().text();
-        return RowData_t();
+        return RowData_T();
     }
 
     select_query.next();
-    RowData_t entry_data;
+    RowData_T entry_data;
 
     for (const auto &column : getTableColumns(data_position.tableName)) {
         entry_data.insert(column, select_query.value(column));
@@ -420,28 +420,28 @@ AEntry ADatabase::getEntry(DataPosition data_position)
     return entry;
 }
 
-APilotEntry ADatabase::getPilotEntry(RowId_t row_id)
+APilotEntry ADatabase::getPilotEntry(RowId_T row_id)
 {
     APilotEntry pilot_entry(row_id);
     pilot_entry.setData(getEntryData(pilot_entry.getPosition()));
     return pilot_entry;
 }
 
-ATailEntry ADatabase::getTailEntry(RowId_t row_id)
+ATailEntry ADatabase::getTailEntry(RowId_T row_id)
 {
     ATailEntry tail_entry(row_id);
     tail_entry.setData(getEntryData(tail_entry.getPosition()));
     return tail_entry;
 }
 
-AAircraftEntry ADatabase::getAircraftEntry(RowId_t row_id)
+AAircraftEntry ADatabase::getAircraftEntry(RowId_T row_id)
 {
     AAircraftEntry aircraft_entry(row_id);
     aircraft_entry.setData(getEntryData(aircraft_entry.getPosition()));
     return aircraft_entry;
 }
 
-AFlightEntry ADatabase::getFlightEntry(RowId_t row_id)
+AFlightEntry ADatabase::getFlightEntry(RowId_T row_id)
 {
     AFlightEntry flight_entry(row_id);
     flight_entry.setData(getEntryData(flight_entry.getPosition()));
@@ -497,7 +497,7 @@ const QStringList ADatabase::getCompletionList(ADatabaseTarget target)
 }
 
 const
-QMap<QString, RowId_t> ADatabase::getIdMap(ADatabaseTarget target)
+QMap<QString, RowId_T> ADatabase::getIdMap(ADatabaseTarget target)
 {
     QString statement;
 
@@ -538,7 +538,7 @@ QMap<QString, RowId_t> ADatabase::getIdMap(ADatabaseTarget target)
     }
 
     // QVector<QString> query_result;  // [G]: unused
-    auto id_map = QMap<QString, RowId_t>();
+    auto id_map = QMap<QString, RowId_T>();
     while (query.next()) {
         id_map.insert(query.value(1).toString(), query.value(0).toInt());
     }
@@ -573,7 +573,7 @@ int ADatabase::getLastEntry(ADatabaseTarget target)
     }
 }
 
-QList<RowId_t> ADatabase::getForeignKeyConstraints(RowId_t foreign_row_id, ADatabaseTarget target)
+QList<RowId_T> ADatabase::getForeignKeyConstraints(RowId_T foreign_row_id, ADatabaseTarget target)
 {
     QString statement = "SELECT ROWID FROM flights WHERE ";
 
@@ -610,12 +610,12 @@ QList<RowId_t> ADatabase::getForeignKeyConstraints(RowId_t foreign_row_id, AData
     return row_ids;
 }
 
-APilotEntry ADatabase::resolveForeignPilot(ForeignKey_t foreign_key)
+APilotEntry ADatabase::resolveForeignPilot(ForeignKey_T foreign_key)
 {
     return aDB->getPilotEntry(foreign_key);
 }
 
-ATailEntry ADatabase::resolveForeignTail(ForeignKey_t foreign_key)
+ATailEntry ADatabase::resolveForeignTail(ForeignKey_T foreign_key)
 {
     return aDB->getTailEntry(foreign_key);
 }

--- a/src/database/adatabase.h
+++ b/src/database/adatabase.h
@@ -31,7 +31,7 @@
 #include <QSqlRecord>
 #include <QSqlField>
 
-#include "src/database/declarations.h"
+#include "src/database/adatabasetypes.h"
 #include "src/classes/aentry.h"
 #include "src/classes/apilotentry.h"
 #include "src/classes/atailentry.h"
@@ -89,33 +89,20 @@ public:
 class ADatabase : public QObject {
     Q_OBJECT
 public:
-    using RowId_t = int;
-
-    using PilotName_t = QString;
-    using PilotRowId_t = RowId_t;
-
-    using TailRgstr_t = QString;
-    using TailId_t = RowId_t;
-
-    using ArprtICAO_t = QString;
-    using ArprtIATA_t = QString;
-    using ArprtName_t = QString;
-    using ArprtId_t = RowId_t;
-
 
 private:
     ADatabase();
 
     static ADatabase* self;
-    TableNames tableNames;
-    TableColumns tableColumns;
+    TableNames_t tableNames;
+    TableColumns_t tableColumns;
 public:
     // Ensure DB is not copiable or assignable
     ADatabase(const ADatabase&) = delete;
     void operator=(const ADatabase&) = delete;
     static ADatabase* instance();
-    TableNames getTableNames() const;
-    ColumnNames getTableColumns(TableName table_name) const;
+    TableNames_t getTableNames() const;
+    ColumnNames_t getTableColumns(TableName_t table_name) const;
     void updateLayout();
     const QString sqliteVersion();
 
@@ -183,7 +170,7 @@ public:
     /*!
      * \brief retreive entry data from the database to create an entry object
      */
-    RowData getEntryData(DataPosition data_position);
+    RowData_t getEntryData(DataPosition data_position);
 
     /*!
      * \brief retreive an Entry from the database.
@@ -198,7 +185,7 @@ public:
      * instead of an Entry. It allows for easy access to a pilot entry
      * with only the RowId required as input.
      */
-    APilotEntry getPilotEntry(RowId row_id);
+    APilotEntry getPilotEntry(RowId_t row_id);
 
     /*!
      * \brief retreives a TailEntry from the database.
@@ -208,7 +195,7 @@ public:
      * instead of an Entry. It allows for easy access to a tail entry
      * with only the RowId required as input.
      */
-    ATailEntry getTailEntry(RowId row_id);
+    ATailEntry getTailEntry(RowId_t row_id);
 
     /*!
      * \brief retreives a TailEntry from the database.
@@ -218,7 +205,7 @@ public:
      * instead of an AEntry. It allows for easy access to an aircraft entry
      * with only the RowId required as input.
      */
-    AAircraftEntry getAircraftEntry(RowId row_id);
+    AAircraftEntry getAircraftEntry(RowId_t row_id);
 
     /*!
      * \brief retreives a flight entry from the database.
@@ -228,7 +215,7 @@ public:
      * instead of an AEntry. It allows for easy access to a flight entry
      * with only the RowId required as input.
      */
-    AFlightEntry getFlightEntry(RowId row_id);
+    AFlightEntry getFlightEntry(RowId_t row_id);
 
     /*!
      * \brief getCompletionList returns a QStringList of values for a
@@ -237,7 +224,7 @@ public:
     const QStringList getCompletionList(ADatabaseTarget target);
 
     /*!
-     * \brief returns a QMap<QueryResult_qstr, QueryResult_i> of a human-readable database value and
+     * \brief returns a QMap<QString, RowId_t> of a human-readable database value and
      * its row id. Used in the Dialogs to map user input to unique database entries.
      */
     const QMap<QString, RowId_t> getIdMap(ADatabaseTarget target);
@@ -251,19 +238,19 @@ public:
      * \brief returns a list of ROWID's in the flights table for which foreign key constraints
      * exist.
      */
-    QList<int> getForeignKeyConstraints(int foreign_row_id, ADatabaseTarget target);
+    QList<RowId_t> getForeignKeyConstraints(RowId_t foreign_row_id, ADatabaseTarget target);
 
     /*!
      * \brief Resolves the foreign key in a flight entry
      * \return The Pilot Entry referencted by the foreign key.
      */
-    APilotEntry resolveForeignPilot(int foreign_key);
+    APilotEntry resolveForeignPilot(ForeignKey_t foreign_key);
 
     /*!
      * \brief Resolves the foreign key in a flight entry
      * \return The Tail Entry referencted by the foreign key.
      */
-    ATailEntry resolveForeignTail(int foreign_key);
+    ATailEntry resolveForeignTail(ForeignKey_t foreign_key);
 
 
 

--- a/src/database/adatabase.h
+++ b/src/database/adatabase.h
@@ -94,15 +94,15 @@ private:
     ADatabase();
 
     static ADatabase* self;
-    TableNames_t tableNames;
-    TableColumns_t tableColumns;
+    TableNames_T tableNames;
+    TableColumns_T tableColumns;
 public:
     // Ensure DB is not copiable or assignable
     ADatabase(const ADatabase&) = delete;
     void operator=(const ADatabase&) = delete;
     static ADatabase* instance();
-    TableNames_t getTableNames() const;
-    ColumnNames_t getTableColumns(TableName_t table_name) const;
+    TableNames_T getTableNames() const;
+    ColumnNames_T getTableColumns(TableName_T table_name) const;
     void updateLayout();
     const QString sqliteVersion();
 
@@ -170,7 +170,7 @@ public:
     /*!
      * \brief retreive entry data from the database to create an entry object
      */
-    RowData_t getEntryData(DataPosition data_position);
+    RowData_T getEntryData(DataPosition data_position);
 
     /*!
      * \brief retreive an Entry from the database.
@@ -185,7 +185,7 @@ public:
      * instead of an Entry. It allows for easy access to a pilot entry
      * with only the RowId required as input.
      */
-    APilotEntry getPilotEntry(RowId_t row_id);
+    APilotEntry getPilotEntry(RowId_T row_id);
 
     /*!
      * \brief retreives a TailEntry from the database.
@@ -195,7 +195,7 @@ public:
      * instead of an Entry. It allows for easy access to a tail entry
      * with only the RowId required as input.
      */
-    ATailEntry getTailEntry(RowId_t row_id);
+    ATailEntry getTailEntry(RowId_T row_id);
 
     /*!
      * \brief retreives a TailEntry from the database.
@@ -205,7 +205,7 @@ public:
      * instead of an AEntry. It allows for easy access to an aircraft entry
      * with only the RowId required as input.
      */
-    AAircraftEntry getAircraftEntry(RowId_t row_id);
+    AAircraftEntry getAircraftEntry(RowId_T row_id);
 
     /*!
      * \brief retreives a flight entry from the database.
@@ -215,7 +215,7 @@ public:
      * instead of an AEntry. It allows for easy access to a flight entry
      * with only the RowId required as input.
      */
-    AFlightEntry getFlightEntry(RowId_t row_id);
+    AFlightEntry getFlightEntry(RowId_T row_id);
 
     /*!
      * \brief getCompletionList returns a QStringList of values for a
@@ -226,8 +226,9 @@ public:
     /*!
      * \brief returns a QMap<QString, RowId_t> of a human-readable database value and
      * its row id. Used in the Dialogs to map user input to unique database entries.
+     * \todo What is this QString semantically? As i understand its a "QueryResult" QVariant cast to QString
      */
-    const QMap<QString, RowId_t> getIdMap(ADatabaseTarget target);
+    const QMap<QString, RowId_T> getIdMap(ADatabaseTarget target);
 
     /*!
      * \brief returns the ROWID for the newest entry in the respective database.
@@ -238,19 +239,19 @@ public:
      * \brief returns a list of ROWID's in the flights table for which foreign key constraints
      * exist.
      */
-    QList<RowId_t> getForeignKeyConstraints(RowId_t foreign_row_id, ADatabaseTarget target);
+    QList<RowId_T> getForeignKeyConstraints(RowId_T foreign_row_id, ADatabaseTarget target);
 
     /*!
      * \brief Resolves the foreign key in a flight entry
      * \return The Pilot Entry referencted by the foreign key.
      */
-    APilotEntry resolveForeignPilot(ForeignKey_t foreign_key);
+    APilotEntry resolveForeignPilot(ForeignKey_T foreign_key);
 
     /*!
      * \brief Resolves the foreign key in a flight entry
      * \return The Tail Entry referencted by the foreign key.
      */
-    ATailEntry resolveForeignTail(ForeignKey_t foreign_key);
+    ATailEntry resolveForeignTail(ForeignKey_T foreign_key);
 
 
 

--- a/src/database/adatabase.h
+++ b/src/database/adatabase.h
@@ -88,6 +88,23 @@ public:
  */
 class ADatabase : public QObject {
     Q_OBJECT
+public:
+
+    using QueryResult_qstr = QString;
+    using QueryResult_i = int;
+
+    using PilotName_qstr = QueryResult_qstr;
+    using PilotRowId_i = QueryResult_i;
+
+    using TailRgstr_qstr = QueryResult_qstr;
+    using TailId_i = QueryResult_i;
+
+    using ArprtICAO_qstr = QueryResult_qstr;
+    using ArprtIATA_qstr = QueryResult_qstr;
+    using ArprtName_qstr = QueryResult_qstr;
+    using ArprtId_i = QueryResult_i;
+
+
 private:
     ADatabase();
 
@@ -219,18 +236,18 @@ public:
      * \brief getCompletionList returns a QStringList of values for a
      * QCompleter based on database values
      */
-    const QStringList getCompletionList(ADatabaseTarget);
+    const QStringList getCompletionList(ADatabaseTarget target);
 
     /*!
-     * \brief returns a QMap<QString, int> of a human-readable database value and
+     * \brief returns a QMap<QueryResult_qstr, QueryResult_i> of a human-readable database value and
      * its row id. Used in the Dialogs to map user input to unique database entries.
      */
-    const QMap<QString, int> getIdMap(ADatabaseTarget);
+    const QMap<QueryResult_qstr, QueryResult_i> getIdMap(ADatabaseTarget target);
 
     /*!
      * \brief returns the ROWID for the newest entry in the respective database.
      */
-    int getLastEntry(ADatabaseTarget);
+    int getLastEntry(ADatabaseTarget target);
 
     /*!
      * \brief returns a list of ROWID's in the flights table for which foreign key constraints

--- a/src/database/adatabase.h
+++ b/src/database/adatabase.h
@@ -89,20 +89,18 @@ public:
 class ADatabase : public QObject {
     Q_OBJECT
 public:
+    using RowId_t = int;
 
-    using QueryResult_qstr = QString;
-    using QueryResult_i = int;
+    using PilotName_t = QString;
+    using PilotRowId_t = RowId_t;
 
-    using PilotName_qstr = QueryResult_qstr;
-    using PilotRowId_i = QueryResult_i;
+    using TailRgstr_t = QString;
+    using TailId_t = RowId_t;
 
-    using TailRgstr_qstr = QueryResult_qstr;
-    using TailId_i = QueryResult_i;
-
-    using ArprtICAO_qstr = QueryResult_qstr;
-    using ArprtIATA_qstr = QueryResult_qstr;
-    using ArprtName_qstr = QueryResult_qstr;
-    using ArprtId_i = QueryResult_i;
+    using ArprtICAO_t = QString;
+    using ArprtIATA_t = QString;
+    using ArprtName_t = QString;
+    using ArprtId_t = RowId_t;
 
 
 private:
@@ -242,7 +240,7 @@ public:
      * \brief returns a QMap<QueryResult_qstr, QueryResult_i> of a human-readable database value and
      * its row id. Used in the Dialogs to map user input to unique database entries.
      */
-    const QMap<QueryResult_qstr, QueryResult_i> getIdMap(ADatabaseTarget target);
+    const QMap<QString, RowId_t> getIdMap(ADatabaseTarget target);
 
     /*!
      * \brief returns the ROWID for the newest entry in the respective database.

--- a/src/database/adatabasetypes.h
+++ b/src/database/adatabasetypes.h
@@ -19,38 +19,41 @@
 #define DECLARATIONS_H
 
 #include <QtCore>
-#include "src/oplconstants.h"
 #include "src/testing/adebug.h"
 
-/// \todo Break apart these aliases to their
-/// corresponding sub section of the program
-/// eg DB related to ADatabase.h and so on
+// [G]: TODO. Break apart these aliases to their
+// corresponding sub section of the program
+// eg DB related to ADatabase.h and so on
 
-/*!
- * \brief An alias for QString
- *
- * Very long description *with* **markdown?**
- * - - -
- * # Header
- */
-using ColName = QString;
-using ColData = QVariant;
-using TableName = QString;
-using RowId = int;
+using RowId_t = int;
+using PilotName_t = QString;
+using PilotRowId_t = RowId_t;
+using TailRgstr_t = QString;
+using TailId_t = RowId_t;
+using ArprtICAO_t = QString;
+using ArprtIATA_t = QString;
+using ArprtName_t = QString;
+using ArprtId_t = RowId_t;
+using ColName_t = QString;
+using ColData_t = QVariant;
+using TableName_t = QString;
+using RowId_t = int;
 
-using TableNames = QStringList;
-using RowData = QMap<ColName, ColData>;
-using ColumnData = QPair<ColName, ColData>;
-using ColumnNames = QStringList;
-using TableColumns = QMap<TableName, ColumnNames>;
+using TableNames_t = QStringList;
+using RowData_t = QMap<ColName_t, ColData_t>;
+using ColumnData_t = QPair<ColName_t, ColData_t>;
+using ColumnNames_t = QStringList;
+using TableColumns_t = QMap<TableName_t, ColumnNames_t>;
+
+using ForeignKey_t = int;
 
 struct DataPosition {
-    TableName tableName;
-    RowId rowId;
+    TableName_t tableName;
+    RowId_t rowId;
     DataPosition()
-        : tableName(TableName())
+        : tableName(TableName_t())
     {};
-    DataPosition(TableName table_name, RowId row_id)
+    DataPosition(TableName_t table_name, RowId_t row_id)
         : tableName(table_name), rowId(row_id)
     {};
 
@@ -62,11 +65,5 @@ struct DataPosition {
          + ", rowId=" + QString::number(object.rowId)
          )
 };
-
-// Default Positions
-static auto const DEFAULT_FLIGHT_POSITION   = DataPosition(Opl::Db::TABLE_FLIGHTS, 0);
-static auto const DEFAULT_PILOT_POSITION    = DataPosition(Opl::Db::TABLE_PILOTS, 0);
-static auto const DEFAULT_TAIL_POSITION     = DataPosition(Opl::Db::TABLE_TAILS, 0);
-static auto const DEFAULT_AIRCRAFT_POSITION = DataPosition(Opl::Db::TABLE_AIRCRAFT, 0);
 
 #endif // DECLARATIONS_H

--- a/src/database/adatabasetypes.h
+++ b/src/database/adatabasetypes.h
@@ -21,39 +21,35 @@
 #include <QtCore>
 #include "src/testing/adebug.h"
 
-// [G]: TODO. Break apart these aliases to their
-// corresponding sub section of the program
-// eg DB related to ADatabase.h and so on
+/// \todo Short descriptions
+using RowId_T = int;
+using PilotName_T = QString;
+using PilotRowId_T = RowId_T;
+using TailRegistration_T = QString;
+using TailId_T = RowId_T;
+using AirportICAO_T = QString;
+using AirportIATA_T = QString;
+using AirportName_T = QString;
+using AirportId_T = RowId_T;
+using ColName_T = QString;
+using ColData_T = QVariant;
+using TableName_T = QString;
 
-using RowId_t = int;
-using PilotName_t = QString;
-using PilotRowId_t = RowId_t;
-using TailRgstr_t = QString;
-using TailId_t = RowId_t;
-using ArprtICAO_t = QString;
-using ArprtIATA_t = QString;
-using ArprtName_t = QString;
-using ArprtId_t = RowId_t;
-using ColName_t = QString;
-using ColData_t = QVariant;
-using TableName_t = QString;
-using RowId_t = int;
+using TableNames_T = QStringList;
+using RowData_T = QMap<ColName_T, ColData_T>;
+using ColumnData_T = QPair<ColName_T, ColData_T>;
+using ColumnNames_T = QStringList;
+using TableColumns_T = QMap<TableName_T, ColumnNames_T>;
 
-using TableNames_t = QStringList;
-using RowData_t = QMap<ColName_t, ColData_t>;
-using ColumnData_t = QPair<ColName_t, ColData_t>;
-using ColumnNames_t = QStringList;
-using TableColumns_t = QMap<TableName_t, ColumnNames_t>;
-
-using ForeignKey_t = int;
+using ForeignKey_T = RowId_T;
 
 struct DataPosition {
-    TableName_t tableName;
-    RowId_t rowId;
+    TableName_T tableName;
+    RowId_T rowId;
     DataPosition()
-        : tableName(TableName_t())
+        : tableName(TableName_T())
     {};
-    DataPosition(TableName_t table_name, RowId_t row_id)
+    DataPosition(TableName_T table_name, RowId_T row_id)
         : tableName(table_name), rowId(row_id)
     {};
 

--- a/src/database/declarations.h
+++ b/src/database/declarations.h
@@ -22,6 +22,10 @@
 #include "src/oplconstants.h"
 #include "src/testing/adebug.h"
 
+/// \todo Break apart these aliases to their
+/// corresponding sub section of the program
+/// eg DB related to ADatabase.h and so on
+
 /*!
  * \brief An alias for QString
  *

--- a/src/gui/dialogues/newflightdialog.cpp
+++ b/src/gui/dialogues/newflightdialog.cpp
@@ -525,9 +525,9 @@ void NewFlightDialog::fillDeductibleData()
  * no input validation is done in this step and input data is assumed to be valid.
  * \return
  */
-RowData_t NewFlightDialog::collectInput()
+RowData_T NewFlightDialog::collectInput()
 {
-    RowData_t newData;
+    RowData_T newData;
     DEB << "Collecting Input...";
     //Block Time
     const auto tofb = ATime::fromString(ui->tofbTimeLineEdit->text());

--- a/src/gui/dialogues/newflightdialog.cpp
+++ b/src/gui/dialogues/newflightdialog.cpp
@@ -525,9 +525,9 @@ void NewFlightDialog::fillDeductibleData()
  * no input validation is done in this step and input data is assumed to be valid.
  * \return
  */
-RowData NewFlightDialog::collectInput()
+RowData_t NewFlightDialog::collectInput()
 {
-    RowData newData;
+    RowData_t newData;
     DEB << "Collecting Input...";
     //Block Time
     const auto tofb = ATime::fromString(ui->tofbTimeLineEdit->text());

--- a/src/gui/dialogues/newflightdialog.h
+++ b/src/gui/dialogues/newflightdialog.h
@@ -35,7 +35,7 @@
 #include "src/classes/aflightentry.h"
 #include "src/classes/apilotentry.h"
 #include "src/classes/atailentry.h"
-
+#include "src/database/adatabase.h"
 
 namespace Ui {
 class NewFlight;
@@ -44,7 +44,14 @@ class NewFlight;
 class NewFlightDialog : public QDialog
 {
     Q_OBJECT
-
+    using PilotName_qstr = ADatabase::PilotName_qstr;
+    using PilotRowId_i = ADatabase::PilotRowId_i;
+    using TailRgstr_qstr = ADatabase::TailRgstr_qstr;
+    using TailId_i = ADatabase::TailId_i;
+    using ArprtICAO_qstr = ADatabase::ArprtICAO_qstr;
+    using ArprtIATA_qstr = ADatabase::ArprtIATA_qstr;
+    using ArprtName_qstr = ADatabase::ArprtName_qstr;
+    using ArprtId_i = ADatabase::ArprtId_i;
 public:
     /*!
      * \brief NewFlightDialog create a new flight and add it to the logbook.
@@ -129,11 +136,11 @@ private:
     /*!
      * \brief Used to map user input to database keys
      */
-    QMap<QString, int> pilotsIdMap;
-    QMap<QString, int> tailsIdMap;
-    QMap<QString, int> airportIcaoIdMap;
-    QMap<QString, int> airportIataIdMap;
-    QMap<QString, int> airportNameIdMap;
+    QMap<PilotName_qstr, PilotRowId_i> pilotsIdMap;
+    QMap<TailRgstr_qstr, TailId_i> tailsIdMap;
+    QMap<ArprtICAO_qstr, ArprtId_i> airportIcaoIdMap;
+    QMap<ArprtIATA_qstr, ArprtId_i> airportIataIdMap;
+    QMap<ArprtName_qstr, ArprtId_i> airportNameIdMap;
 
     Opl::Time::FlightTimeFormat flightTimeFormat;
 

--- a/src/gui/dialogues/newflightdialog.h
+++ b/src/gui/dialogues/newflightdialog.h
@@ -128,11 +128,11 @@ private:
     /*!
      * \brief Used to map user input to database keys
      */
-    QMap<PilotName_t, PilotRowId_t> pilotsIdMap;
-    QMap<TailRgstr_t, TailId_t> tailsIdMap;
-    QMap<ArprtICAO_t, ArprtId_t> airportIcaoIdMap;
-    QMap<ArprtIATA_t, ArprtId_t> airportIataIdMap;
-    QMap<ArprtName_t, ArprtId_t> airportNameIdMap;
+    QMap<PilotName_T, PilotRowId_T> pilotsIdMap;
+    QMap<TailRegistration_T, TailId_T> tailsIdMap;
+    QMap<AirportICAO_T, AirportId_T> airportIcaoIdMap;
+    QMap<AirportIATA_T, AirportId_T> airportIataIdMap;
+    QMap<AirportName_T, AirportId_T> airportNameIdMap;
 
     Opl::Time::FlightTimeFormat flightTimeFormat;
 
@@ -161,7 +161,7 @@ private:
     void addNewTail(QLineEdit*);
     void addNewPilot(QLineEdit *);
 
-    RowData_t collectInput();
+    RowData_T collectInput();
 
     /*!
      * \brief converts a time string as used in the UI to an integer of minutes for

--- a/src/gui/dialogues/newflightdialog.h
+++ b/src/gui/dialogues/newflightdialog.h
@@ -44,14 +44,14 @@ class NewFlight;
 class NewFlightDialog : public QDialog
 {
     Q_OBJECT
-    using PilotName_qstr = ADatabase::PilotName_qstr;
-    using PilotRowId_i = ADatabase::PilotRowId_i;
-    using TailRgstr_qstr = ADatabase::TailRgstr_qstr;
-    using TailId_i = ADatabase::TailId_i;
-    using ArprtICAO_qstr = ADatabase::ArprtICAO_qstr;
-    using ArprtIATA_qstr = ADatabase::ArprtIATA_qstr;
-    using ArprtName_qstr = ADatabase::ArprtName_qstr;
-    using ArprtId_i = ADatabase::ArprtId_i;
+    using PilotName_t = ADatabase::PilotName_t;
+    using PilotRowId_t = ADatabase::PilotRowId_t;
+    using TailRgstr_t = ADatabase::TailRgstr_t;
+    using TailId_t = ADatabase::TailId_t;
+    using ArprtICAO_t = ADatabase::ArprtICAO_t;
+    using ArprtIATA_t = ADatabase::ArprtIATA_t;
+    using ArprtName_t = ADatabase::ArprtName_t;
+    using ArprtId_t = ADatabase::ArprtId_t;
 public:
     /*!
      * \brief NewFlightDialog create a new flight and add it to the logbook.
@@ -129,18 +129,18 @@ private:
     /*!
      * To be used by the QCompleters
      */
-    QStringList pilotList;
+    QStringList pilotList;QVariant
     QStringList tailsList;
     QStringList airportList;
 
     /*!
      * \brief Used to map user input to database keys
      */
-    QMap<PilotName_qstr, PilotRowId_i> pilotsIdMap;
-    QMap<TailRgstr_qstr, TailId_i> tailsIdMap;
-    QMap<ArprtICAO_qstr, ArprtId_i> airportIcaoIdMap;
-    QMap<ArprtIATA_qstr, ArprtId_i> airportIataIdMap;
-    QMap<ArprtName_qstr, ArprtId_i> airportNameIdMap;
+    QMap<PilotName_t, PilotRowId_t> pilotsIdMap;
+    QMap<TailRgstr_t, TailId_t> tailsIdMap;
+    QMap<ArprtICAO_t, ArprtId_t> airportIcaoIdMap;
+    QMap<ArprtIATA_t, ArprtId_t> airportIataIdMap;
+    QMap<ArprtName_t, ArprtId_t> airportNameIdMap;
 
     Opl::Time::FlightTimeFormat flightTimeFormat;
 

--- a/src/gui/dialogues/newflightdialog.h
+++ b/src/gui/dialogues/newflightdialog.h
@@ -44,14 +44,6 @@ class NewFlight;
 class NewFlightDialog : public QDialog
 {
     Q_OBJECT
-    using PilotName_t = ADatabase::PilotName_t;
-    using PilotRowId_t = ADatabase::PilotRowId_t;
-    using TailRgstr_t = ADatabase::TailRgstr_t;
-    using TailId_t = ADatabase::TailId_t;
-    using ArprtICAO_t = ADatabase::ArprtICAO_t;
-    using ArprtIATA_t = ADatabase::ArprtIATA_t;
-    using ArprtName_t = ADatabase::ArprtName_t;
-    using ArprtId_t = ADatabase::ArprtId_t;
 public:
     /*!
      * \brief NewFlightDialog create a new flight and add it to the logbook.
@@ -129,7 +121,7 @@ private:
     /*!
      * To be used by the QCompleters
      */
-    QStringList pilotList;QVariant
+    QStringList pilotList;
     QStringList tailsList;
     QStringList airportList;
 
@@ -169,7 +161,7 @@ private:
     void addNewTail(QLineEdit*);
     void addNewPilot(QLineEdit *);
 
-    RowData collectInput();
+    RowData_t collectInput();
 
     /*!
      * \brief converts a time string as used in the UI to an integer of minutes for

--- a/src/gui/dialogues/newpilotdialog.cpp
+++ b/src/gui/dialogues/newpilotdialog.cpp
@@ -141,7 +141,7 @@ void NewPilotDialog::submitForm()
 {
     DEB << "Collecting User Input...";
 
-    RowData_t new_data;
+    RowData_T new_data;
     auto line_edits = this->findChildren<QLineEdit *>();
     for(auto& le : line_edits) {
         auto key = le->objectName().remove(QStringLiteral("LineEdit"));

--- a/src/gui/dialogues/newpilotdialog.cpp
+++ b/src/gui/dialogues/newpilotdialog.cpp
@@ -141,7 +141,7 @@ void NewPilotDialog::submitForm()
 {
     DEB << "Collecting User Input...";
 
-    RowData new_data;
+    RowData_t new_data;
     auto line_edits = this->findChildren<QLineEdit *>();
     for(auto& le : line_edits) {
         auto key = le->objectName().remove(QStringLiteral("LineEdit"));

--- a/src/gui/dialogues/newtaildialog.cpp
+++ b/src/gui/dialogues/newtaildialog.cpp
@@ -187,7 +187,7 @@ bool NewTailDialog::verify()
 void NewTailDialog::submitForm()
 {
     DEB << "Creating Database Object...";
-    RowData new_data;
+    RowData_t new_data;
     //retreive Line Edits
     auto line_edits = this->findChildren<QLineEdit *>();
     line_edits.removeOne(this->findChild<QLineEdit *>(QStringLiteral("searchLineEdit")));

--- a/src/gui/dialogues/newtaildialog.cpp
+++ b/src/gui/dialogues/newtaildialog.cpp
@@ -187,7 +187,7 @@ bool NewTailDialog::verify()
 void NewTailDialog::submitForm()
 {
     DEB << "Creating Database Object...";
-    RowData_t new_data;
+    RowData_T new_data;
     //retreive Line Edits
     auto line_edits = this->findChildren<QLineEdit *>();
     line_edits.removeOne(this->findChild<QLineEdit *>(QStringLiteral("searchLineEdit")));

--- a/src/gui/widgets/settingswidget.cpp
+++ b/src/gui/widgets/settingswidget.cpp
@@ -135,7 +135,7 @@ void SettingsWidget::setupValidators()
 
 void SettingsWidget::updatePersonalDetails()
 {
-    RowData user_data;
+    RowData_t user_data;
     switch (ui->aliasComboBox->currentIndex()) {
     case 0:
         user_data.insert(Opl::Db::PILOTS_ALIAS, QStringLiteral("self"));

--- a/src/gui/widgets/settingswidget.cpp
+++ b/src/gui/widgets/settingswidget.cpp
@@ -135,7 +135,7 @@ void SettingsWidget::setupValidators()
 
 void SettingsWidget::updatePersonalDetails()
 {
-    RowData_t user_data;
+    RowData_T user_data;
     switch (ui->aliasComboBox->currentIndex()) {
     case 0:
         user_data.insert(Opl::Db::PILOTS_ALIAS, QStringLiteral("self"));

--- a/src/oplconstants.h
+++ b/src/oplconstants.h
@@ -19,6 +19,7 @@
 #define OPLCONSTANTS_H
 
 #include <QtCore>
+#include "src/database/adatabasetypes.h"
 
 /*!
  *  \brief A namespace to collect constants and enums used throughout the application.
@@ -163,6 +164,11 @@ static const auto PILOTS_EMAIL           = QStringLiteral("email");
 static const auto ROWID                  = QStringLiteral("ROWID");
 static const auto EMPTY_STRING           = QStringLiteral("");
 static const auto NULL_TIME_hhmm         = QStringLiteral("00:00");
+
+static const auto DEFAULT_FLIGHT_POSITION   = DataPosition(TABLE_FLIGHTS, 0);
+static const auto DEFAULT_PILOT_POSITION    = DataPosition(TABLE_PILOTS, 0);
+static const auto DEFAULT_TAIL_POSITION     = DataPosition(TABLE_TAILS, 0);
+static const auto DEFAULT_AIRCRAFT_POSITION = DataPosition(TABLE_AIRCRAFT, 0);
 
 } // namespace opl::db
 


### PR DESCRIPTION
closes #59 
 
In an attempt to give semantic meaning to bare QStrings and ints i propose aliasing these types with names suited for the program.

## Proposal
`using [semantic_name]_[aliased_type] = [aliased_type];`
While the names can be debated to achieve developer clarity, the idea is that those aliases hold the semantic meaning of the type and  after `_` the mechanical meaning.

### Examples
```c++
using TableName_qstr = QString;
using RowId_i = int;
using RgstrNum_i8 = int8_t;

using PilotKey_qstr = QString;
using PIlotKeys_qvec = QVector<QString>
```